### PR TITLE
[Routine - VT] fix(mcp): guard validate_json_structure against non-object array elements

### DIFF
--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -591,6 +591,10 @@ export class VirtualTabsMCPServer {
               const seenIds = new Set<string>();
               for (let i = 0; i < parsed.length; i++) {
                 const g = parsed[i];
+                if (!g || typeof g !== 'object') {
+                  errors.push(`Group[${i}] must be an object.`);
+                  continue;
+                }
                 if (!g.id) { errors.push(`Group[${i}] missing "id".`); }
                 else if (seenIds.has(g.id)) { errors.push(`Duplicate id "${g.id}" at index ${i}.`); }
                 else { seenIds.add(g.id); }


### PR DESCRIPTION
## Pre-flight Check

- `gh pr list --state open` returned no open PRs at the time of this run.
- Checked remote routine branches (`git branch -r | grep routine`): ~20 exist, but every one of them is already squash-merged into `main` (verified via `gh pr list --state closed`, e.g. #74–#98). None are active/unmerged, so there is nothing to overlap with.
- No `AGENTS.md` exists in the repo root.
- This PR touches only `mcp-server/src/server.ts`, inside the `validate_json_structure` tool handler — not touched by any recent commit.

## Changes

`validate_json_structure` iterates the parsed JSON array and immediately reads `g.id` / `g.name` / `g.files` off each element. If an element is `null`, a string, or a number (e.g. `[null, {...}]`), that throws a `TypeError`, which the outer `try/catch` swallows and reports back to the AI agent as a misleading `"JSON parse error"` for otherwise well-formed JSON.

This is the same bug class as the earlier merged fix "guard files iteration in validate_json_structure against undefined" (#82) — that one guarded `g.files`; this one guards `g` itself. Added a single early-continue guard:

```ts
if (!g || typeof g !== 'object') {
  errors.push(`Group[${i}] must be an object.`);
  continue;
}
```

Confirms this PR does **not**:
- add/rename/remove any VS Code command registrations
- add/rename/remove any contributed configuration keys in `package.json`
- add, remove, or update any dependencies
- modify the core tab-group serialization format or config storage/migration logic
- touch `package.json`/`package-lock.json` version fields or `CHANGELOG.md`

## Safety Verification

Commands run locally, all passed:

```
npx tsc -p ./                     # PASS, no errors
npm run test                      # tsc -p ./ && jest --runInBand → 31 suites / 203 tests passed
cd mcp-server && npx tsc --noEmit # PASS, no errors (mcp-server has no dedicated test script; same as the precedent fix #82)
```

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` consolidation are intentionally deferred to the weekend release/integration PR. If CI fails solely due to the repository's version-bump release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>