### PR TITLE
[Routine - VT] fix(commands): use localized postfix when stripping copy suffix in duplicateGroup

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -531,7 +531,7 @@ export function registerCommands(
         if (!group || group.builtIn) return;
 
         // Generate new name
-        let base = group.name.replace(/\s*Copy( \d+)?$/, '');
+        let base = I18n.stripCopyPostfix(group.name);
         let idx = 1;
         let newName = I18n.getCopyGroupName(base);
         while (provider.groups.some(g => g.name === newName)) {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -121,6 +121,18 @@ export class I18n {
     }
 
     /**
+     * Strip a previously-applied copy postfix (and optional trailing index) from a name,
+     * using the currently loaded locale's postfix rather than a hardcoded English literal.
+     * @param name Name that may end with "<postfix>" or "<postfix> <n>"
+     * @returns Name with the postfix removed, if present
+     */
+    public static stripCopyPostfix(name: string): string {
+        const postfix = this.getMessage('group.copyPostfix');
+        const escaped = postfix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        return name.replace(new RegExp(`\\s*${escaped}( \\d+)?$`), '');
+    }
+
+    /**
      * Check if initialized
      * @returns Whether initialized
      */

--- a/src/test/unit/copyGroupName.test.ts
+++ b/src/test/unit/copyGroupName.test.ts
@@ -1,0 +1,28 @@
+jest.mock('vscode', () => ({}), { virtual: true });
+
+import { I18n } from '../../i18n';
+
+describe('I18n.stripCopyPostfix', () => {
+    // With no language file loaded, getMessage('group.copyPostfix') falls back to the
+    // key itself, so the postfix used for stripping is the literal string 'group.copyPostfix'.
+    const postfix = 'group.copyPostfix';
+
+    test('strips a trailing postfix with no index', () => {
+        expect(I18n.stripCopyPostfix(`Notes ${postfix}`)).toBe('Notes');
+    });
+
+    test('strips a trailing postfix followed by an index', () => {
+        expect(I18n.stripCopyPostfix(`Notes ${postfix} 2`)).toBe('Notes');
+    });
+
+    test('leaves a name without the postfix unchanged', () => {
+        expect(I18n.stripCopyPostfix('Notes')).toBe('Notes');
+    });
+
+    test('is used by getCopyGroupName round-trip so repeated duplication does not stack postfixes', () => {
+        const original = 'Notes';
+        const firstCopy = I18n.getCopyGroupName(original);
+        const strippedAgain = I18n.stripCopyPostfix(firstCopy);
+        expect(strippedAgain).toBe(original);
+    });
+});


### PR DESCRIPTION
## Pre-flight Check

- Open PRs checked: #104 (`routine/vt-fix-validatejson-nonobject-element-260727`), which modifies `mcp-server/src/server.ts` (guards `validate_json_structure` against non-object array elements).
- Active routine/* remote branches were also reviewed (bookmark relpath, autogroup bookmarks, watcher disposal, sendTo malformed target, i18n dollar placeholder, groupmanager cache/json handling, etc.) — none touch `src/commands.ts` or `src/i18n.ts`.
- This PR only touches `src/commands.ts` (the `duplicateGroup` handler) and `src/i18n.ts` (adds a new static helper), plus a new unit test file. No overlap with #104 or any other open work.

## Changes

- `src/i18n.ts`: added `I18n.stripCopyPostfix(name)`, which strips a previously-applied copy suffix using the **currently loaded locale's** postfix message (`group.copyPostfix`) instead of a hardcoded English literal.
- `src/commands.ts`: the `virtualTabs.duplicateGroup` handler previously stripped a prior copy suffix with a regex hardcoded to the English word `Copy` (`/\s*Copy( \d+)?$/`), while `I18n.getCopyGroupName()` appends the localized postfix (`"副本"` in zh-cn, `"複本"` in zh-tw, `"Copy"` in en). Under a non-English VS Code locale, the strip never matched, so repeated "Duplicate Group" invocations stacked the postfix instead of incrementing an index (e.g. `"Notes 副本"` → `"Notes 副本 副本"` → `"Notes 副本 副本 副本"`, unbounded growth). Now it calls `I18n.stripCopyPostfix(group.name)`, which strips correctly under any loaded locale.
- `src/test/unit/copyGroupName.test.ts`: new unit tests for `I18n.stripCopyPostfix`, including a round-trip test with `getCopyGroupName` to guard against postfix-stacking regressions.

Confirms this PR does **not**:
- Add/rename/delete any VS Code command registration
- Add/rename/delete any contributed configuration key in `package.json`
- Modify `package.json` / `package-lock.json`, or add/remove/update dependencies
- Modify the tab-group serialization format or config storage/migration logic

## Safety Verification

Commands run locally, in order:

```bash
npx tsc -p ./
```
→ passed, no errors.

```bash
npm run test:coverage
```
→ passed: `Test Suites: 32 passed, 32 total`, `Tests: 207 passed, 207 total` (includes the 4 new tests in `copyGroupName.test.ts`).

No `lint` or `format:check` npm scripts exist in this repo, so those steps were skipped as instructed.

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump (`package.json` / `package-lock.json`) and `CHANGELOG.md` consolidation are intentionally deferred to the weekend release/integration PR. If CI fails only due to the repository's version-bump gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.