### PR TITLE
[Routine - VT] fix(provider): surface save failures to the user

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -63,6 +63,7 @@
     "message.configReloaded": "VirtualTabs: Config reloaded successfully.",
     "message.configDeleted": "VirtualTabs: Config file deleted. Groups reset to default.",
     "error.loadConfigFailed": "Failed to load virtualTab.json",
+    "error.saveConfigFailed": "Failed to save virtualTab.json",
     "error.invalidConfigFormat": "Invalid format in virtualTab.json. Please check the file structure.",
     "mcp.configCopied": "MCP configuration copied to clipboard!",
     "mcp.generatedCursorRule": "VirtualTabs: Generated Cursor rule. Run 'VirtualTabs: Show MCP Config' to view the full setup guide.",

--- a/i18n/zh-cn.json
+++ b/i18n/zh-cn.json
@@ -63,6 +63,7 @@
     "message.configReloaded": "VirtualTabs: 配置已重新加载",
     "message.configDeleted": "VirtualTabs: 配置文件已删除，群组已重置为默认状态。",
     "error.loadConfigFailed": "加载 virtualTab.json 失败",
+    "error.saveConfigFailed": "保存 virtualTab.json 失败",
     "error.invalidConfigFormat": "virtualTab.json 格式错误，请检查文件结构。",
     "mcp.configCopied": "MCP 配置已复制到剪贴板！",
     "mcp.generatedCursorRule": "VirtualTabs: 已生成 Cursor 规则。请执行 'VirtualTabs: Show MCP Config' 查看完整配置指南。",

--- a/i18n/zh-tw.json
+++ b/i18n/zh-tw.json
@@ -63,6 +63,7 @@
     "message.configReloaded": "VirtualTabs: 配置已重新載入。",
     "message.configDeleted": "VirtualTabs: 配置檔案已刪除，群組已重設為預設狀態。",
     "error.loadConfigFailed": "載入 virtualTab.json 失敗",
+    "error.saveConfigFailed": "儲存 virtualTab.json 失敗",
     "error.invalidConfigFormat": "virtualTab.json 格式錯誤，請檢查檔案結構。",
     "mcp.configCopied": "MCP 配置已複製到剪貼簿！",
     "mcp.generatedCursorRule": "VirtualTabs: 已產生 Cursor 規則。請執行 'VirtualTabs: Show MCP Config' 查看完整配置指南。",

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -440,6 +440,7 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
         } catch (error) {
             this.isInternalSaving = false;
             console.error('Failed to save VirtualTabs data file:', error);
+            vscode.window.showErrorMessage(`${I18n.getMessage('error.saveConfigFailed') || 'Failed to save virtualTab.json'}: ${error instanceof Error ? error.message : String(error)}`);
         }
     }
 


### PR DESCRIPTION
## 1. Pre-flight Check

Open PRs at the time of this run:
- #105 `routine/vt-fix-copygroupname-i18n-260728` — touches `src/commands.ts`, `src/i18n.ts`, `src/test/unit/copyGroupName.test.ts`
- #104 `routine/vt-fix-validatejson-nonobject-element-260727` — touches `mcp-server/src/server.ts`

Recent/active `routine/vt-fix-*` remote branches were also reviewed (bookmark relpath, watcher scope, treeview listener disposal, groupmanager cache/json guards, i18n placeholder, dragdrop bookmark key, autogroup bookmarks/builtin visibility, sendTo guards, filesorter tests, jumptobookmark clamp, mcp workspace poll, scopeheader foldername, flush pending save, etc.).

This PR touches only `src/provider.ts` (one catch block) and the three i18n message catalogs (`i18n/en.json`, `i18n/zh-cn.json`, `i18n/zh-tw.json`) to add a single new message key. It does not modify `src/commands.ts`, `src/i18n.ts` (the i18n loader/logic), `mcp-server/`, or any file/topic touched by the PRs or branches above.

## 2. Changes

`saveGroupsImmediate` in `src/provider.ts` persists all group/bookmark edits to `virtualTab.json` on a 500ms debounce. Its outer catch block only logged failures via `console.error`, so if the write throws (disk full, file locked by another process/AV, permissions error, workspace folder becoming unavailable) the user's reorganization could be silently lost — they'd only discover it on next reload when the tree reverts.

This PR adds a `vscode.window.showErrorMessage(...)` call alongside the existing `console.error`, following the exact same pattern already used for the sibling load-failure path (`error.loadConfigFailed` at `src/provider.ts:546`). A new `error.saveConfigFailed` key was added to all three locale catalogs for this.

Confirms this PR does **not**:
- add/remove/rename any VS Code command registrations
- add/remove/rename any contributed configuration keys in `package.json`
- touch `package.json` / `package-lock.json`
- add/remove/update any dependency
- modify the tab-group serialization format or configuration storage/migration logic

## 3. Safety Verification

Commands run locally, all passed:
- `npx tsc -p ./` — no errors
- `npm run test` (`tsc -p ./ && jest --runInBand`) — 31 suites / 203 tests passed
- `npm run test:coverage` (matches CI's `validate.yml` test command) — 31 suites / 203 tests passed, 100% statement/line coverage on changed files

No `lint` or `format:check` scripts exist in this repo, so those steps were skipped.

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` updates are intentionally deferred to the weekend release/integration PR. If CI fails only due to the repository's version-bump/release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.