### PR TITLE
[Routine - VT] fix(core): normalize bookmark key lookup in AutoGrouper

### DIFF
--- a/src/core/AutoGrouper.ts
+++ b/src/core/AutoGrouper.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { GroupManager } from './GroupManager.js';
 import { FileManager } from './FileManager.js';
 import { PathUtils } from './PathUtils.js';
+import { BookmarkManager } from './BookmarkManager.js';
 import { SortCriteria, DateGroup, TempGroup } from '../types.js';
 
 export class AutoGrouper {
@@ -97,19 +98,23 @@ export class AutoGrouper {
    * sub-group, mirroring the same-file-move logic in dragAndDrop.ts.
    * Without this, bookmarks are orphaned on the (now empty) source group
    * and become unreachable from the UI.
+   *
+   * Looks up the stored bookmark key via BookmarkManager.findBookmarkKey
+   * rather than an exact match on fileUri, since the stored key can differ
+   * in encoding/casing from the group's `files` entries (see dragAndDrop.ts).
    */
   static moveBookmarks(sourceGroup: TempGroup, targetGroup: TempGroup, fileUris: string[]): void {
     if (!sourceGroup.bookmarks) return;
 
     for (const fileUri of fileUris) {
-      const bookmarks = sourceGroup.bookmarks[fileUri];
-      if (!bookmarks) continue;
+      const bookmarkKey = BookmarkManager.findBookmarkKey(sourceGroup, fileUri);
+      if (!bookmarkKey || !sourceGroup.bookmarks[bookmarkKey]) continue;
 
       if (!targetGroup.bookmarks) {
         targetGroup.bookmarks = {};
       }
-      targetGroup.bookmarks[fileUri] = bookmarks;
-      delete sourceGroup.bookmarks[fileUri];
+      targetGroup.bookmarks[bookmarkKey] = sourceGroup.bookmarks[bookmarkKey];
+      delete sourceGroup.bookmarks[bookmarkKey];
     }
 
     if (Object.keys(sourceGroup.bookmarks).length === 0) {

--- a/src/test/unit/autoGrouperBookmarks.test.ts
+++ b/src/test/unit/autoGrouperBookmarks.test.ts
@@ -92,6 +92,30 @@ describe('AutoGrouper — bookmark migration on auto-grouping', () => {
         expect(dateGroup.bookmarks?.[fileUri]).toHaveLength(1);
     });
 
+    test('groupByExtension moves bookmarks even when the stored key differs in encoding from the file URI', () => {
+        // Mirrors dragAndDrop.ts: the bookmark key on disk can be a raw fs path
+        // while group.files stores the file:// URI form of the same file.
+        const tsPath = path.join(tmpDir, 'a.ts');
+        const tsUri = fileManager.toFileUri(tsPath);
+
+        writeConfig(tmpDir, [{
+            id: 'g1',
+            name: 'Mixed',
+            files: [tsUri],
+            bookmarks: { [tsPath]: [makeBookmark()] }
+        }]);
+
+        const result = autoGrouper.groupByExtension('g1');
+        expect(result.created).toBe(1);
+
+        const { groups } = groupManager.loadGroups();
+        const source = groups.find(g => g.id === 'g1')!;
+        const tsGroup = groups.find(g => g.autoGroupType === 'extension' && g.files?.includes(tsUri))!;
+
+        expect(source.bookmarks).toBeUndefined();
+        expect(tsGroup.bookmarks?.[tsPath]).toHaveLength(1);
+    });
+
     test('groupByExtension leaves source untouched when it has no bookmarks', () => {
         const tsUri = fileManager.toFileUri(path.join(tmpDir, 'a.ts'));
 


### PR DESCRIPTION
## Pre-flight Check

Open PRs checked (Phase 1):
- #106 `routine/vt-fix-savegroups-silent-error-260730` — touches `i18n/en.json`, `i18n/zh-cn.json`, `i18n/zh-tw.json`, `src/provider.ts`
- #105 `routine/vt-fix-copygroupname-i18n-260728` — touches `src/commands.ts`, `src/i18n.ts`, `src/test/unit/copyGroupName.test.ts`
- #104 `routine/vt-fix-validatejson-nonobject-element-260727` — touches `mcp-server/src/server.ts`

This PR only touches `src/core/AutoGrouper.ts` and `src/test/unit/autoGrouperBookmarks.test.ts`, which none of the above PRs modify. No overlap.

## Changes

`AutoGrouper.moveBookmarks` (used by both the MCP-layer `groupByExtension`/`groupByDate` and the UI's Auto Group commands) looked up bookmarks with an exact-string match: `sourceGroup.bookmarks[fileUri]`. Elsewhere in the codebase (`dragAndDrop.ts`, hardened previously for the same reason), the stored bookmark key is known to sometimes differ from the corresponding `group.files` entry in encoding/casing (e.g. a raw fs path vs. a `file://` URI), which `BookmarkManager.findBookmarkKey` already exists to resolve.

Because `moveBookmarks` didn't use that normalized lookup, a bookmark whose stored key mismatched the file URI was silently left behind (orphaned) on the emptied source group instead of following its file into the new auto-created sub-group.

Fix: `moveBookmarks` now resolves the key via `BookmarkManager.findBookmarkKey(sourceGroup, fileUri)` before reading/deleting, mirroring the existing `dragAndDrop.ts` logic. Added a regression test (`groupByExtension moves bookmarks even when the stored key differs in encoding from the file URI`) alongside the existing bookmark-migration tests.

Confirms this PR does **not** modify VS Code command registrations, contributed configuration keys (`package.json`), dependencies, or the tab-group serialization/storage format.

## Safety Verification

Commands run locally, all passed:
- `npx tsc -p ./` — no errors
- `npm run test` (`tsc -p ./ && jest --runInBand`) — 31 suites / 204 tests passed

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` updates are intentionally deferred to the weekend release/integration PR. If CI fails solely due to the repository's version-bump gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.