### PR TITLE
[Routine - VT] fix(dragAndDrop): guard isDescendant against cyclic parentGroupId chains

### DIFF
--- a/src/dragAndDrop.ts
+++ b/src/dragAndDrop.ts
@@ -374,13 +374,16 @@ export class TempFoldersDragAndDropController implements vscode.TreeDragAndDropC
     /**
      * Check if a group is a descendant of another group (prevent circular nesting)
      */
-    private isDescendant(groupId: string, potentialAncestorId: string): boolean {
+    private isDescendant(groupId: string, potentialAncestorId: string, visited = new Set<string>()): boolean {
+        if (visited.has(groupId)) return false;
+        visited.add(groupId);
+
         const group = this.provider.groups.find(g => g.id === groupId);
         if (!group || !group.parentGroupId) return false;
 
         if (group.parentGroupId === potentialAncestorId) return true;
 
-        return this.isDescendant(group.parentGroupId, potentialAncestorId);
+        return this.isDescendant(group.parentGroupId, potentialAncestorId, visited);
     }
 
     private collectGroupFilesRecursive(groupId: string): string[] {

--- a/src/test/unit/dragIsDescendantCycleGuard.test.ts
+++ b/src/test/unit/dragIsDescendantCycleGuard.test.ts
@@ -1,0 +1,69 @@
+/**
+ * 單元測試：isDescendant 的循環父群組防護
+ *
+ * 驗證：
+ * 1. 正常的祖先鏈仍可正確判斷
+ * 2. 非祖先關係回傳 false
+ * 3. 循環的 parentGroupId 鏈不會造成無窮遞迴（visited 集合防護）
+ */
+
+interface FakeGroup {
+    id: string;
+    parentGroupId?: string;
+}
+
+/**
+ * 模擬 isDescendant 的核心邏輯（修正後版本，含 visited 防護）。
+ */
+function isDescendant(groups: FakeGroup[], groupId: string, potentialAncestorId: string, visited = new Set<string>()): boolean {
+    if (visited.has(groupId)) return false;
+    visited.add(groupId);
+
+    const group = groups.find(g => g.id === groupId);
+    if (!group || !group.parentGroupId) return false;
+
+    if (group.parentGroupId === potentialAncestorId) return true;
+
+    return isDescendant(groups, group.parentGroupId, potentialAncestorId, visited);
+}
+
+describe('isDescendant 循環防護', () => {
+    test('直接子群組應判斷為後代', () => {
+        const groups: FakeGroup[] = [
+            { id: 'parent', parentGroupId: undefined },
+            { id: 'child', parentGroupId: 'parent' }
+        ];
+        expect(isDescendant(groups, 'child', 'parent')).toBe(true);
+    });
+
+    test('多層巢狀後代應判斷為 true', () => {
+        const groups: FakeGroup[] = [
+            { id: 'grandparent' },
+            { id: 'parent', parentGroupId: 'grandparent' },
+            { id: 'child', parentGroupId: 'parent' }
+        ];
+        expect(isDescendant(groups, 'child', 'grandparent')).toBe(true);
+    });
+
+    test('無關群組應判斷為 false', () => {
+        const groups: FakeGroup[] = [
+            { id: 'a' },
+            { id: 'b' }
+        ];
+        expect(isDescendant(groups, 'a', 'b')).toBe(false);
+    });
+
+    test('循環的 parentGroupId 鏈不應無窮遞迴，且回傳 false', () => {
+        const groups: FakeGroup[] = [
+            { id: 'g1', parentGroupId: 'g2' },
+            { id: 'g2', parentGroupId: 'g1' }
+        ];
+        expect(() => isDescendant(groups, 'g1', 'unrelated')).not.toThrow();
+        expect(isDescendant(groups, 'g1', 'unrelated')).toBe(false);
+    });
+
+    test('自我循環（parentGroupId 指向自己）不應無窮遞迴', () => {
+        const groups: FakeGroup[] = [{ id: 'g1', parentGroupId: 'g1' }];
+        expect(() => isDescendant(groups, 'g1', 'unrelated')).not.toThrow();
+    });
+});

--- a/src/test/unit/dragIsDescendantCycleGuard.test.ts
+++ b/src/test/unit/dragIsDescendantCycleGuard.test.ts
@@ -7,7 +7,7 @@
  * 3. 循環的 parentGroupId 鏈不會造成無窮遞迴（visited 集合防護）
  */
 
-interface FakeGroup {
+interface FakeParentGroup {
     id: string;
     parentGroupId?: string;
 }
@@ -15,7 +15,7 @@ interface FakeGroup {
 /**
  * 模擬 isDescendant 的核心邏輯（修正後版本，含 visited 防護）。
  */
-function isDescendant(groups: FakeGroup[], groupId: string, potentialAncestorId: string, visited = new Set<string>()): boolean {
+function isDescendant(groups: FakeParentGroup[], groupId: string, potentialAncestorId: string, visited = new Set<string>()): boolean {
     if (visited.has(groupId)) return false;
     visited.add(groupId);
 
@@ -29,7 +29,7 @@ function isDescendant(groups: FakeGroup[], groupId: string, potentialAncestorId:
 
 describe('isDescendant 循環防護', () => {
     test('直接子群組應判斷為後代', () => {
-        const groups: FakeGroup[] = [
+        const groups: FakeParentGroup[] = [
             { id: 'parent', parentGroupId: undefined },
             { id: 'child', parentGroupId: 'parent' }
         ];
@@ -37,7 +37,7 @@ describe('isDescendant 循環防護', () => {
     });
 
     test('多層巢狀後代應判斷為 true', () => {
-        const groups: FakeGroup[] = [
+        const groups: FakeParentGroup[] = [
             { id: 'grandparent' },
             { id: 'parent', parentGroupId: 'grandparent' },
             { id: 'child', parentGroupId: 'parent' }
@@ -46,7 +46,7 @@ describe('isDescendant 循環防護', () => {
     });
 
     test('無關群組應判斷為 false', () => {
-        const groups: FakeGroup[] = [
+        const groups: FakeParentGroup[] = [
             { id: 'a' },
             { id: 'b' }
         ];
@@ -54,7 +54,7 @@ describe('isDescendant 循環防護', () => {
     });
 
     test('循環的 parentGroupId 鏈不應無窮遞迴，且回傳 false', () => {
-        const groups: FakeGroup[] = [
+        const groups: FakeParentGroup[] = [
             { id: 'g1', parentGroupId: 'g2' },
             { id: 'g2', parentGroupId: 'g1' }
         ];
@@ -63,7 +63,7 @@ describe('isDescendant 循環防護', () => {
     });
 
     test('自我循環（parentGroupId 指向自己）不應無窮遞迴', () => {
-        const groups: FakeGroup[] = [{ id: 'g1', parentGroupId: 'g1' }];
+        const groups: FakeParentGroup[] = [{ id: 'g1', parentGroupId: 'g1' }];
         expect(() => isDescendant(groups, 'g1', 'unrelated')).not.toThrow();
     });
 });


### PR DESCRIPTION
## Pre-flight Check

Open PRs / active branches checked (Phase 1):
- #107 `routine/vt-fix-autogrouper-bookmark-key-260731` — touches `src/core/AutoGrouper.ts`, `src/test/unit/autoGrouperBookmarks.test.ts`
- #106 `routine/vt-fix-savegroups-silent-error-260730` — touches `i18n/en.json`, `i18n/zh-cn.json`, `i18n/zh-tw.json`, `src/provider.ts`
- #105 `routine/vt-fix-copygroupname-i18n-260728` — touches `src/commands.ts`, `src/i18n.ts`, `src/test/unit/copyGroupName.test.ts`
- #104 `routine/vt-fix-validatejson-nonobject-element-260727` — touches `mcp-server/src/server.ts`

This PR only touches `src/dragAndDrop.ts` and adds a new test file `src/test/unit/dragIsDescendantCycleGuard.test.ts`. Neither file overlaps with any file touched by the PRs above, so there is no conflict or duplicate work.

## Changes

`TempFoldersDragAndDropController.isDescendant()` in [src/dragAndDrop.ts](src/dragAndDrop.ts) recursively walks a group's `parentGroupId` chain to detect circular nesting during drag-and-drop, but had no cycle guard — unlike the sibling `collectGroupFilesRecursive()` method a few lines below it, which already uses a `visited` Set for the same kind of parent/child traversal. If a group's `parentGroupId` chain ever became cyclic (e.g. from a hand-edited or corrupted `.vscode` config file), the next drag-and-drop operation touching that cycle would recurse indefinitely and could crash/hang the extension host.

Fix: added a `visited` Set parameter to `isDescendant`, mirroring the existing pattern used in `collectGroupFilesRecursive`. Behavior for the normal (acyclic) case is unchanged; a cyclic chain now safely returns `false` instead of recursing forever.

Added `src/test/unit/dragIsDescendantCycleGuard.test.ts` covering: direct ancestor detection, multi-level ancestor detection, unrelated groups, a 2-node cycle, and a self-referencing cycle.

This PR does **not**:
- add, rename, or remove any VS Code command registrations
- add, rename, or remove any contributed configuration keys in `package.json`
- add/remove/update any dependencies
- modify the tab-group serialization or storage format

## Safety Verification

Commands run locally, all passed:
```
npx tsc -p ./
npx jest --runInBand src/test/unit/dragIsDescendantCycleGuard.test.ts   # 5 passed
npm run test:coverage                                                   # 32 suites / 208 tests passed
```

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump (`package.json`/`package-lock.json`) and `CHANGELOG.md` updates are intentionally deferred to the weekend release/integration PR. If CI's version-bump gate flags this PR once labeled `release-ready`, that is expected release-readiness behavior, not a code validation failure — this PR does not carry that label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)