### PR TITLE
[Routine - VT] fix(mcp): isolate per-agent skill generation failures

### DIFF
--- a/src/mcp/SkillGenerator.ts
+++ b/src/mcp/SkillGenerator.ts
@@ -126,20 +126,26 @@ export class SkillGenerator {
             const skillPaths: string[] = [];
 
             for (const choice of choices) {
-                if (choice.value === 'cursor') {
-                    skillPaths.push(await this.generateCursorRule(context, projectRoot, mcpServerScriptPath));
-                } else if (choice.value === 'antigravity') {
-                    skillPaths.push(await this.generateVSCodeSkill(context, projectRoot, mcpServerScriptPath, '.agents'));
-                } else if (choice.value === 'claude') {
-                    skillPaths.push(await this.generateVSCodeSkill(context, projectRoot, mcpServerScriptPath, '.claude'));
-                } else if (choice.value === 'copilot') {
-                    skillPaths.push(await this.generateVSCodeSkill(context, projectRoot, mcpServerScriptPath, '.github'));
-                } else if (choice.value === 'kiro') {
-                    skillPaths.push(await this.generateVSCodeSkill(context, projectRoot, mcpServerScriptPath, '.kiro'));
-                } else if (choice.value === 'cline') {
-                    skillPaths.push(await this.generateVSCodeSkill(context, projectRoot, mcpServerScriptPath, '.cline'));
-                } else if (choice.value === 'gemini') {
-                    skillPaths.push(await this.generateVSCodeSkill(context, projectRoot, mcpServerScriptPath, '.gemini'));
+                try {
+                    if (choice.value === 'cursor') {
+                        skillPaths.push(await this.generateCursorRule(context, projectRoot, mcpServerScriptPath));
+                    } else if (choice.value === 'antigravity') {
+                        skillPaths.push(await this.generateVSCodeSkill(context, projectRoot, mcpServerScriptPath, '.agents'));
+                    } else if (choice.value === 'claude') {
+                        skillPaths.push(await this.generateVSCodeSkill(context, projectRoot, mcpServerScriptPath, '.claude'));
+                    } else if (choice.value === 'copilot') {
+                        skillPaths.push(await this.generateVSCodeSkill(context, projectRoot, mcpServerScriptPath, '.github'));
+                    } else if (choice.value === 'kiro') {
+                        skillPaths.push(await this.generateVSCodeSkill(context, projectRoot, mcpServerScriptPath, '.kiro'));
+                    } else if (choice.value === 'cline') {
+                        skillPaths.push(await this.generateVSCodeSkill(context, projectRoot, mcpServerScriptPath, '.cline'));
+                    } else if (choice.value === 'gemini') {
+                        skillPaths.push(await this.generateVSCodeSkill(context, projectRoot, mcpServerScriptPath, '.gemini'));
+                    }
+                } catch (error) {
+                    vscode.window.showErrorMessage(
+                        `Failed to generate skill for ${choice.label}: ${error instanceof Error ? error.message : String(error)}`
+                    );
                 }
             }
 


### PR DESCRIPTION
## Pre-flight Check

Open PRs checked (via `gh pr list --state open`):
- #108 `routine/vt-fix-isdescendant-cycle-guard-260801` — touches `src/dragAndDrop.ts`, `src/test/unit/dragIsDescendantCycleGuard.test.ts`
- #107 `routine/vt-fix-autogrouper-bookmark-key-260731` — touches `src/core/AutoGrouper.ts`, `src/test/unit/autoGrouperBookmarks.test.ts`
- #106 `routine/vt-fix-savegroups-silent-error-260730` — touches `i18n/en.json`, `i18n/zh-cn.json`, `i18n/zh-tw.json`, `src/provider.ts`
- #105 `routine/vt-fix-copygroupname-i18n-260728` — touches `src/commands.ts`, `src/i18n.ts`, `src/test/unit/copyGroupName.test.ts`
- #104 `routine/vt-fix-validatejson-nonobject-element-260727` — touches `mcp-server/src/server.ts`

This PR only touches `src/mcp/SkillGenerator.ts`, which none of the above PRs modify. No overlap.

## Changes

`SkillGenerator.generateSkill()` iterates over the AI agents the user selected in a multi-pick QuickPick and calls `generateCursorRule`/`generateVSCodeSkill` for each. Those helpers read the extension's bundled `dist/skills/virtualtabs/SKILL.md` template and `dist/vt.bundle.js` (via `getVtBundleContent`, which explicitly throws a descriptive error if the bundle is missing). Previously the loop had no error handling, so:
- A single failing agent (e.g. missing/unbuilt `dist/` assets) aborted the entire batch, silently dropping any agents not yet processed.
- The error propagated unhandled up through the `virtualTabs.generateAgentSkill` command registration in `commands.ts` (which itself has no try/catch), surfacing to the user as VS Code's generic "command failed" notification instead of an actionable message.

The fix wraps each per-agent generation call in a `try/catch` inside the loop, showing a targeted `vscode.window.showErrorMessage` naming the failed agent while letting the remaining selected agents still complete successfully.

Confirms this PR does **not**:
- Add/rename/remove any VS Code command registrations
- Add/rename/remove any contributed configuration keys in `package.json`
- Modify dependencies
- Touch the core tab-group serialization/storage format

## Safety Verification

Commands run locally, both passed:
```
npx tsc -p ./
```
```
npm run test
```
Result: `tsc` clean; Jest — 31 test suites, 203 tests, all passed.

No `lint` or `format:check` npm scripts exist in this project, so those steps were skipped.

`src/mcp/SkillGenerator.ts` imports `vscode` and isn't part of this repo's pure-logic unit-test set (`src/core/*` files with no `vscode` dependency), so no new unit test was added — consistent with prior routine PRs that touched vscode-layer files (e.g. #106 touched `src/provider.ts` with no accompanying test).

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump (`package.json`/`package-lock.json`) and `CHANGELOG.md` updates are intentionally deferred to the weekend release/integration PR. If CI fails solely due to the repository's version-bump release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.