### PR TITLE
[Routine - VT] fix(core): don't let a failed corrupted-config backup block recovery

### DIFF
--- a/src/core/GroupManager.ts
+++ b/src/core/GroupManager.ts
@@ -177,16 +177,21 @@ export class GroupManager {
    * Handle a corrupted config file
    */
   private handleCorruptedConfig(): void {
-    try {
-      if (fs.existsSync(this.configPath)) {
+    // Backing up the corrupted file is best-effort: if it fails (read-only
+    // dir, disk full, AV lock, etc.) we must still fall back to a default
+    // config below, otherwise saveGroups() keeps comparing against the
+    // corrupted file's real mtime forever and every save throws
+    // OptimisticLockError.
+    if (fs.existsSync(this.configPath)) {
+      try {
         const backupPath = `${this.configPath}.backup.${Date.now()}`;
         fs.copyFileSync(this.configPath, backupPath);
         console.error(`Config file corrupted, backup created: ${backupPath}`);
+      } catch (error) {
+        console.error(`Failed to back up corrupted config (continuing without backup): ${error}`);
       }
-      this.createDefaultConfig();
-    } catch (error) {
-      console.error(`Error handling corrupted config: ${error}`);
     }
+    this.createDefaultConfig();
   }
 
   /**

--- a/src/test/unit/groupManagerNonArrayConfig.test.ts
+++ b/src/test/unit/groupManagerNonArrayConfig.test.ts
@@ -65,4 +65,31 @@ describe('GroupManager — non-array config content', () => {
 
         expect(groups).toEqual([]);
     });
+
+    test('recovers to a usable default config even if backing up the corrupted file fails', () => {
+        writeRawConfig(tmpDir, JSON.stringify({ id: 'g1', name: 'Not an array' }));
+
+        // `import * as fs` is wrapped by TS's esModuleInterop helper with a
+        // non-configurable getter, so spyOn must target the real module
+        // object (the one the getter forwards to) to affect GroupManager's
+        // own `fs` reference.
+        const realFs: typeof fs = require('fs');
+        const copyFileSpy = jest.spyOn(realFs, 'copyFileSync').mockImplementation(() => {
+            throw new Error('EACCES: permission denied');
+        });
+
+        try {
+            const manager = new GroupManager(tmpDir);
+            const { groups, version } = manager.loadGroups();
+
+            expect(groups).toEqual([]);
+
+            // A subsequent save with the version returned above must succeed —
+            // previously a backup failure left lastModified stale, so this
+            // would throw OptimisticLockError forever.
+            expect(() => manager.saveGroups([], version)).not.toThrow();
+        } finally {
+            copyFileSpy.mockRestore();
+        }
+    });
 });


### PR DESCRIPTION
## 1. Pre-flight Check

Open PRs and touched files checked before selecting this fix:

| PR | Title | Touched files |
|----|-------|----------------|
| #110 | chore(deps): bump npm_and_yarn group | `mcp-server/package-lock.json`, `mcp-server/package.json`, `package-lock.json`, `package.json` |
| #109 | fix(mcp): isolate per-agent skill generation failures | `src/mcp/SkillGenerator.ts` |
| #108 | fix(dragAndDrop): guard isDescendant against cyclic parentGroupId chains | `src/dragAndDrop.ts`, `src/test/unit/dragIsDescendantCycleGuard.test.ts` |
| #107 | fix(core): normalize bookmark key lookup in AutoGrouper | `src/core/AutoGrouper.ts`, `src/test/unit/autoGrouperBookmarks.test.ts` |
| #106 | fix(provider): surface save failures to the user | `i18n/en.json`, `i18n/zh-cn.json`, `i18n/zh-tw.json`, `src/provider.ts` |
| #105 | fix(commands): use localized postfix when stripping copy suffix | `src/commands.ts`, `src/i18n.ts`, `src/test/unit/copyGroupName.test.ts` |
| #104 | fix(mcp): guard validate_json_structure against non-object array elements | `mcp-server/src/server.ts` |

Active remote `routine/*` branches were also reviewed via `git branch -r`; none touch `src/core/GroupManager.ts` or `src/test/unit/groupManagerNonArrayConfig.test.ts`.

**No overlap**: this PR only modifies `src/core/GroupManager.ts` and `src/test/unit/groupManagerNonArrayConfig.test.ts`, neither of which appears in any open PR or active routine branch above.

## 2. Changes

`GroupManager.handleCorruptedConfig()` (invoked from `loadGroups()` when the config JSON is unparsable or not an array) wrapped both the backup-file copy and the default-config recreation in a single try/catch that only logged failures. If `fs.copyFileSync()` threw for any reason (read-only backup directory, disk full, path-length limit, AV lock, etc.), the exception was thrown *before* `createDefaultConfig()` ran, so `lastModified` never got updated. Every subsequent `saveGroups()` call would then compare its version against the corrupted file's real (non-zero) on-disk mtime, see a mismatch, and throw `OptimisticLockError` — a silent, permanent save lockout for that scope, triggered by a plausible real-world I/O failure during exactly the recovery path meant to prevent it.

The fix makes the backup step best-effort (its own try/catch, logged and skipped on failure) while `createDefaultConfig()` always runs afterward, guaranteeing recovery to a usable empty config regardless of whether the backup succeeded.

Confirms this PR does **not**:
- rename/add/delete any VS Code command registration
- rename/add/delete any contributed configuration key in `package.json`
- add/remove/update any dependency
- modify the tab-group serialization format
- change configuration storage logic in a way that could migrate/rewrite/corrupt existing user data (the on-disk JSON schema and write path are unchanged — only the internal error-handling order changed)

## 3. Safety Verification

Commands run locally, in order:

```
npx tsc -p ./
```
✅ Passed, no errors.

```
npm run test
```
(runs `tsc -p ./ && jest --runInBand`)
✅ Passed — `Test Suites: 31 passed, 31 total`, `Tests: 204 passed, 204 total` (includes one new regression test added to `src/test/unit/groupManagerNonArrayConfig.test.ts` that mocks `fs.copyFileSync` to throw and asserts `loadGroups()` still recovers and a subsequent `saveGroups()` with the returned version succeeds).

No `lint` or `format:check` script exists in `package.json`, so those steps were skipped per the routine's conditional instructions.

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump (`package.json`/`package-lock.json`) and `CHANGELOG.md` consolidation are intentionally deferred to the weekend release/integration PR — not part of this change.

If CI fails solely due to the repository's version-bump release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.