### PR TITLE
[Routine - VT] fix(core): don't throw on a malformed file:// URI when matching stored file entries

### DIFF
--- a/src/core/FileEntryMatcher.ts
+++ b/src/core/FileEntryMatcher.ts
@@ -12,7 +12,14 @@ function toComparableFsPath(storedEntry: string, scopeRoot?: string): string | u
     }
 
     if (storedEntry.startsWith('file://')) {
-        return normalizeFsPath(fileURLToPath(storedEntry));
+        try {
+            return normalizeFsPath(fileURLToPath(storedEntry));
+        } catch {
+            // A hand-edited or corrupted config can contain a malformed file:// URI
+            // (e.g. an unescaped '%'). Treat it as non-matching instead of throwing,
+            // so one bad entry doesn't abort the whole add/remove/bookmark operation.
+            return undefined;
+        }
     }
 
     if (path.isAbsolute(storedEntry)) {

--- a/src/test/unit/fileEntryMatcher.test.ts
+++ b/src/test/unit/fileEntryMatcher.test.ts
@@ -54,4 +54,20 @@ describe('matchesStoredFileEntry', () => {
 
         expect(matchesStoredFileEntry('src/provider.ts', targetUri, targetFsPath, scopeRoot)).toBe(false);
     });
+
+    test('returns false instead of throwing for a malformed file:// stored URI', () => {
+        const scopeRoot = path.resolve('/workspace/project');
+        const targetFsPath = path.resolve(scopeRoot, 'src/extension.ts');
+        const targetUri = pathToFileURL(targetFsPath).toString();
+
+        // A lone '%' not followed by two hex digits makes decodeURIComponent (and
+        // fileURLToPath) throw "URI malformed". This can happen with hand-edited
+        // or corrupted config entries.
+        expect(() =>
+            matchesStoredFileEntry('file:///workspace/project/src/100%.ts', targetUri, targetFsPath, scopeRoot)
+        ).not.toThrow();
+        expect(
+            matchesStoredFileEntry('file:///workspace/project/src/100%.ts', targetUri, targetFsPath, scopeRoot)
+        ).toBe(false);
+    });
 });


### PR DESCRIPTION
## 1. Pre-flight Check

Open PRs/branches checked (via `gh pr list --state open` and `gh pr diff <n> --name-only`):

| PR | Files touched |
|----|----|
| #111 | `src/core/GroupManager.ts`, `src/test/unit/groupManagerNonArrayConfig.test.ts` |
| #110 | dependabot deps bump |
| #109 | `src/mcp/SkillGenerator.ts` |
| #108 | `src/dragAndDrop.ts`, `src/test/unit/dragIsDescendantCycleGuard.test.ts` |
| #107 | `src/core/AutoGrouper.ts`, `src/test/unit/autoGrouperBookmarks.test.ts` |
| #106 | `i18n/*.json`, `src/provider.ts` |
| #105 | `src/commands.ts`, `src/i18n.ts`, `src/test/unit/copyGroupName.test.ts` |
| #104 | `mcp-server/src/server.ts` |

This PR only touches `src/core/FileEntryMatcher.ts` and its test file, which do not appear in any open PR's diff, so there is no overlap.

## 2. Changes

`matchesStoredFileEntry()` (used by `FileManager.addFilesToGroup`/`removeFilesFromGroup`, `BookmarkManager.createBookmark`, and `GroupFileRemoval`) called `fileURLToPath()` directly on a stored `file://` entry with no `try/catch`. A malformed URI — e.g. a hand-edited/corrupted config entry with an unescaped `%` such as a file literally named `100%.ts` — makes `fileURLToPath` throw `"URI malformed"`, which propagated up and aborted the *entire* add/remove/bookmark operation for every file in the call, not just the offending entry.

`BookmarkManager.normalizeFileKey` already guards the equivalent call with a try/catch. This PR applies the same defensive pattern to `FileEntryMatcher.toComparableFsPath`: on a malformed URI it now returns `undefined` (treated as "does not match") instead of throwing.

Added a regression test (`fileEntryMatcher.test.ts`) asserting `matchesStoredFileEntry` does not throw and returns `false` for a malformed `file://` stored entry.

This PR does **not** modify any command registrations, contributed configuration keys (`package.json`), dependencies, or the tab-group serialization/storage format. It is a pure defensive-coding fix in a single pure function.

## 3. Safety Verification

Commands run locally, all passed:

```
npx tsc -p ./
npm run test
```

Output: `tsc` produced no errors; `jest --runInBand` → `Test Suites: 31 passed, 31 total`, `Tests: 204 passed, 204 total` (203 pre-existing + 1 new).

No `lint` or `format:check` script exists in `package.json`, so those steps were skipped.

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump (`package.json`/`package-lock.json`) and `CHANGELOG.md` updates are intentionally deferred to the weekend release/integration PR. If CI fails solely due to the repository's version-bump/release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)