### PR TITLE
[Routine - VT] chore(sendTo): remove dead getFilesInDirectory method

### DIFF
--- a/src/sendTo.ts
+++ b/src/sendTo.ts
@@ -453,23 +453,4 @@ export class SendToManager {
             }
         });
     }
-
-    /**
-     * Get all files from a directory recursively.
-     */
-    static getFilesInDirectory(dirPath: string): vscode.Uri[] {
-        const files: vscode.Uri[] = [];
-        if (!fs.existsSync(dirPath) || !fs.statSync(dirPath).isDirectory()) {
-            return files;
-        }
-        for (const entry of fs.readdirSync(dirPath, { withFileTypes: true })) {
-            const fullPath = path.join(dirPath, entry.name);
-            if (entry.isFile()) {
-                files.push(vscode.Uri.file(fullPath));
-            } else if (entry.isDirectory()) {
-                files.push(...this.getFilesInDirectory(fullPath));
-            }
-        }
-        return files;
-    }
 }


### PR DESCRIPTION
## Pre-flight Check

Open PRs checked (via `gh pr list` + `gh pr diff --name-only`):

| # | Title | Touched files |
|---|-------|----------------|
| 112 | fix(core): don't throw on a malformed file:// URI when matching stored file entries | `src/core/FileEntryMatcher.ts`, `src/test/unit/fileEntryMatcher.test.ts` |
| 111 | fix(core): don't let a failed corrupted-config backup block recovery | `src/core/GroupManager.ts`, `src/test/unit/groupManagerNonArrayConfig.test.ts` |
| 110 | chore(deps): bump the npm_and_yarn group (dependabot) | `package.json`, `package-lock.json`, `mcp-server/package.json`, `mcp-server/package-lock.json` |
| 109 | fix(mcp): isolate per-agent skill generation failures | `src/mcp/SkillGenerator.ts` |
| 108 | fix(dragAndDrop): guard isDescendant against cyclic parentGroupId chains | `src/dragAndDrop.ts`, `src/test/unit/dragIsDescendantCycleGuard.test.ts` |
| 107 | fix(core): normalize bookmark key lookup in AutoGrouper | `src/core/AutoGrouper.ts`, `src/test/unit/autoGrouperBookmarks.test.ts` |
| 106 | fix(provider): surface save failures to the user | `i18n/*.json`, `src/provider.ts` |
| 105 | fix(commands): use localized postfix when stripping copy suffix in duplicateGroup | `src/commands.ts`, `src/i18n.ts`, `src/test/unit/copyGroupName.test.ts` |
| 104 | fix(mcp): guard validate_json_structure against non-object array elements | `mcp-server/src/server.ts` |

This PR touches only `src/sendTo.ts`, which none of the above PRs modify. No overlap.

## Changes

`SendToManager.getFilesInDirectory()` in `src/sendTo.ts` was dead code: a `grep` across the entire repo (source + tests) confirmed the only caller was itself (its own recursive call). None of the `virtualTabs.sendTo*` commands in `commands.ts` ever invoke it — those commands only operate on `TempFolderItem`/`TempFileItem` from the VirtualTabs tree view (files already tracked in a group), never on an arbitrary filesystem directory. Recursive directory expansion for drag-and-drop already lives separately in `dragAndDrop.ts`'s `getFilesInDirectoryRecursive`.

Removed the unused method (19 lines). No behavior change — nothing called it.

Confirms this PR does **not** modify commands, contributed configuration keys, dependencies, or tab-group serialization/storage format.

## Safety Verification

Commands run locally, from repo root:

```
npx tsc -p ./
```
✅ Passed, no errors.

```
npm run test
```
✅ Passed — `Test Suites: 31 passed, 31 total`, `Tests: 203 passed, 203 total`.

No `lint` or `format:check` scripts exist in `package.json`, so those steps were skipped.

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` updates are intentionally deferred to the weekend release/integration PR. If CI fails only due to the repository's version-bump gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.