### PR TITLE
[Routine - VT] fix(core): guard exploreProject against invalid maxResults

### DIFF
--- a/src/core/ProjectExplorer.ts
+++ b/src/core/ProjectExplorer.ts
@@ -22,7 +22,12 @@ export class ProjectExplorer {
    * Uses fast-glob syntax; excludes node_modules and other commonly ignored directories.
    */
   async exploreProject(options: ExploreOptions): Promise<{ files: string[], truncated: boolean }> {
-    const { pattern = '**/*', extension, directory, maxResults = 100 } = options;
+    const { pattern = '**/*', extension, directory, maxResults: requestedMaxResults = 100 } = options;
+    // Guard against non-positive/non-integer values (e.g. 0 or negative), which would
+    // otherwise make Array.slice(0, maxResults) silently drop items from the end.
+    const maxResults = Number.isInteger(requestedMaxResults) && requestedMaxResults > 0
+      ? requestedMaxResults
+      : 100;
 
     let baseDir = this.workspaceRoot;
     if (directory) {

--- a/src/test/unit/projectExplorerMaxResults.test.ts
+++ b/src/test/unit/projectExplorerMaxResults.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit test: ProjectExplorer.exploreProject() handling of an invalid maxResults.
+ *
+ * A non-positive or non-integer maxResults (e.g. 0, a negative number, or NaN)
+ * must not be passed straight into Array.slice(0, maxResults) — a negative
+ * value there silently drops items from the *end* of the array instead of
+ * limiting the result count, which is confusing to callers (e.g. MCP tool
+ * clients) expecting a simple upper bound.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ProjectExplorer } from '../../core/ProjectExplorer';
+
+function makeTempWorkspace(fileCount: number): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vt-test-explorer-'));
+    for (let i = 0; i < fileCount; i++) {
+        fs.writeFileSync(path.join(dir, `file${i}.ts`), '');
+    }
+    return dir;
+}
+
+describe('ProjectExplorer.exploreProject — maxResults validation', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = makeTempWorkspace(5);
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    test('a negative maxResults falls back to the default instead of slicing from the end', async () => {
+        const explorer = new ProjectExplorer(tmpDir);
+        const result = await explorer.exploreProject({ maxResults: -1 });
+
+        expect(result.files).toHaveLength(5);
+        expect(result.truncated).toBe(false);
+    });
+
+    test('a zero maxResults falls back to the default', async () => {
+        const explorer = new ProjectExplorer(tmpDir);
+        const result = await explorer.exploreProject({ maxResults: 0 });
+
+        expect(result.files).toHaveLength(5);
+        expect(result.truncated).toBe(false);
+    });
+
+    test('a non-integer maxResults falls back to the default', async () => {
+        const explorer = new ProjectExplorer(tmpDir);
+        const result = await explorer.exploreProject({ maxResults: 1.5 });
+
+        expect(result.files).toHaveLength(5);
+        expect(result.truncated).toBe(false);
+    });
+
+    test('a valid positive maxResults still truncates as requested', async () => {
+        const explorer = new ProjectExplorer(tmpDir);
+        const result = await explorer.exploreProject({ maxResults: 2 });
+
+        expect(result.files).toHaveLength(2);
+        expect(result.truncated).toBe(true);
+    });
+});


### PR DESCRIPTION
## Pre-flight Check

Open PRs checked (10 total, all draft/dependabot):
- #113 `routine/vt-fix-remove-dead-getfilesindirectory-260807` — `src/sendTo.ts`
- #112 `routine/vt-fix-fileentrymatcher-malformed-uri-260806` — `src/core/FileEntryMatcher.ts`
- #111 `routine/vt-fix-corrupted-config-backup-260804` — `src/core/GroupManager.ts`
- #110 `dependabot/npm_and_yarn/npm_and_yarn-c97759f48b` — `package.json` / `package-lock.json` (both dirs)
- #109 `routine/vt-fix-skillgen-error-handling-260802` — `src/mcp/SkillGenerator.ts`
- #108 `routine/vt-fix-isdescendant-cycle-guard-260801` — `src/dragAndDrop.ts`
- #107 `routine/vt-fix-autogrouper-bookmark-key-260731` — `src/core/AutoGrouper.ts`
- #106 `routine/vt-fix-savegroups-silent-error-260730` — `src/provider.ts`, `i18n/*.json`
- #105 `routine/vt-fix-copygroupname-i18n-260728` — `src/commands.ts`, `src/i18n.ts`
- #104 `routine/vt-fix-validatejson-nonobject-element-260727` — `mcp-server/src/server.ts`

This PR touches only `src/core/ProjectExplorer.ts` (plus a new test file), which is not modified by any of the above. No overlap.

## Changes

`ProjectExplorer.exploreProject()` destructured `maxResults` straight from caller-supplied options and passed it directly into `Array.prototype.slice(0, maxResults)`. A non-positive or non-integer value (e.g. `0`, `-1`, `1.5` — plausible from an MCP client that doesn't validate its own input) causes `slice` to behave unexpectedly: a negative `maxResults` silently drops items from the **end** of the result list instead of acting as an upper bound, and `truncated` gets reported inconsistently with what was actually returned.

The fix validates `maxResults` is a positive integer and falls back to the documented default (`100`) otherwise. `ProjectExplorer.ts` had no prior unit test coverage at all, so this PR also adds `src/test/unit/projectExplorerMaxResults.test.ts` covering: negative, zero, non-integer, and normal positive `maxResults`.

Confirms this PR does **not** modify command registrations, contributed configuration keys (`package.json`), dependencies, or the tab-group serialization/storage format.

## Safety Verification

Commands run locally, all passed:
- `npx tsc -p ./` — no errors
- `npm run test` (`tsc -p ./ && jest --runInBand`) — 32 suites / 207 tests passed (up from 31/203 baseline, due to the new test file)

No `lint` or `format:check` script exists in `package.json`, so those steps were skipped.

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and CHANGELOG consolidation are intentionally deferred to the weekend release/integration PR. If CI fails solely due to the repository's version-bump/release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.