### PR TITLE
[Routine - VT] fix(extension): refresh treeView description after workspace folder changes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -260,6 +260,9 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.workspace.onDidChangeWorkspaceFolders(() => {
             // 重新執行 discovery 並更新 provider 的 configScopes
             provider.reinitializeScopes();
+            // reinitializeScopes() 會移除已不存在 scope 的 activeScopeIds，
+            // 若不重新計算 description，面板標頭會停留在移除前的舊範圍文字。
+            treeView.description = provider.computeScopeDescription();
             const currentScopeIds = new Set(provider.configScopes.map(s => s.id));
 
             // 移除 folder 後其 scope 已不存在，dispose 對應的 watcher 避免資源洩漏


### PR DESCRIPTION
## 1. Pre-flight Check

Checked open PRs and active `routine/*` branches before selecting a target (see full list below). This PR touches only `src/extension.ts`, which is not touched by any currently open PR:

| PR | Files touched |
|----|----------------|
| #114 | `src/core/ProjectExplorer.ts`, `src/test/unit/projectExplorerMaxResults.test.ts` |
| #113 | `src/sendTo.ts` |
| #112 | `src/core/FileEntryMatcher.ts`, `src/test/unit/fileEntryMatcher.test.ts` |
| #111 | `src/core/GroupManager.ts`, `src/test/unit/groupManagerNonArrayConfig.test.ts` |
| #110 | `mcp-server/package*.json`, `package*.json` (dependency bump only) |
| #109 | `src/mcp/SkillGenerator.ts` |
| #108 | `src/dragAndDrop.ts`, `src/test/unit/dragIsDescendantCycleGuard.test.ts` |
| #107 | `src/core/AutoGrouper.ts`, `src/test/unit/autoGrouperBookmarks.test.ts` |
| #106 | `i18n/*.json`, `src/provider.ts` |
| #105 | `src/commands.ts`, `src/i18n.ts`, `src/test/unit/copyGroupName.test.ts` |
| #104 | `mcp-server/src/server.ts` |

No open PR or active routine branch touches `src/extension.ts`, so this change does not overlap with any in-flight work.

## 2. Changes

`onDidChangeWorkspaceFolders` in `src/extension.ts` calls `provider.reinitializeScopes()`, which prunes `activeScopeIds` entries for any scope whose workspace folder was just removed. However the `TreeView.description` string (set once at `activate()` time from `provider.computeScopeDescription()`) was never recomputed after that prune, so the panel header could keep showing a stale scope label/count (e.g. still say "2 scopes" after one of the active scopes' folders was removed from the workspace).

Fix: recompute and re-assign `treeView.description` right after `reinitializeScopes()`, mirroring the same pattern already used in `src/commands.ts` for the scope-selection commands.

This PR does **not** modify any VS Code command registrations, contributed configuration keys (`package.json`), dependencies, or the tab-group serialization/storage format. It is a 3-line, single-file change.

## 3. Safety Verification

Commands run locally, all passed:

- `npx tsc -p ./` — no type errors
- `npm run test` (`tsc -p ./ && jest --runInBand`) — 31 test suites / 203 tests passed

No `lint` or `format:check` script exists in `package.json`, so those steps were skipped.

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` updates are intentionally deferred to the weekend release/integration PR. If CI fails solely due to the repository's version-bump gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.