### PR TITLE
fix(core): resolve self-root .code-workspace ConfigScope id collision

### DIFF
--- a/src/core/ConfigScopeDiscovery.ts
+++ b/src/core/ConfigScopeDiscovery.ts
@@ -17,21 +17,28 @@ export class ConfigScopeDiscovery {
      * - 多根工作區（workspaceFile 存在）：回傳一個 workspace scope + 多個 folder scope
      * - 單一資料夾工作區：回傳一個 folder scope
      * - 無工作區資料夾：回傳空陣列
+     * - self-root .code-workspace（workspaceFile 父目錄等於某個 folder）：
+     *   workspace scope 與該 folder scope 的 id 會是同一個 uri.toString()，
+     *   兩者若同時保留會造成 scope id 碰撞（見 provider.ts 的 groupManagers Map key），
+     *   因此略過該 workspace scope，只保留 folder scope 作為唯一資料來源。
      */
     static discover(): ConfigScope[] {
         const scopes: ConfigScope[] = [];
-
-        // 多根工作區：workspaceFile 存在時，建立 workspace scope
-        if (vscode.workspace.workspaceFile) {
-            const workspaceScope = ConfigScopeDiscovery.createWorkspaceScope(vscode.workspace.workspaceFile);
-            scopes.push(workspaceScope);
-        }
 
         // 為每個 workspaceFolder 建立 folder scope
         const folders = vscode.workspace.workspaceFolders;
         if (folders && folders.length > 0) {
             for (const folder of folders) {
                 scopes.push(ConfigScopeDiscovery.createFolderScope(folder));
+            }
+        }
+
+        // 多根工作區：workspaceFile 存在時，建立 workspace scope
+        if (vscode.workspace.workspaceFile) {
+            const workspaceScope = ConfigScopeDiscovery.createWorkspaceScope(vscode.workspace.workspaceFile);
+            const isSelfRootAlias = scopes.some(scope => scope.id === workspaceScope.id);
+            if (!isSelfRootAlias) {
+                scopes.unshift(workspaceScope);
             }
         }
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -77,6 +77,7 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
 
         // 探索所有 ConfigScope，為每個 scope 建立對應的 GroupManager
         this.configScopes = this.applyScopeOrder(ConfigScopeDiscovery.discover());
+        this.assertUniqueScopeIds(this.configScopes);
         for (const scope of this.configScopes) {
             const gm = new GroupManager(this.getConfigStorageRoot(scope));
             this.migrateLegacyWorkspaceConfig(scope, gm);
@@ -102,6 +103,7 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
      */
     public reinitializeScopes(): void {
         this.configScopes = this.applyScopeOrder(ConfigScopeDiscovery.discover());
+        this.assertUniqueScopeIds(this.configScopes);
         for (const id of [...this.activeScopeIds]) {
             if (id !== BUILTIN_SCOPE_ID && !this.configScopes.some(scope => scope.id === id)) {
                 this.activeScopeIds.delete(id);
@@ -128,6 +130,30 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
         this.groups = [...builtInGroups];
         this.loadGroups();
         this.refresh(false);
+    }
+
+    /**
+     * 防禦性檢查：ConfigScope.id 必須唯一，否則後續以 scope.id 為 key 的
+     * groupManagers.set() 會靜默覆蓋前一個 scope 的 GroupManager，導致
+     * loadGroups()/saveGroupsImmediate() 對同一組 scope id 重複讀寫同一份
+     * 設定檔（症狀：群組資料每次啟動倍增）。
+     *
+     * ConfigScopeDiscovery 已針對已知的 self-root .code-workspace 情境
+     * （workspace 父目錄與某個 folder 相同）從根源排除碰撞，這裡是最後一道
+     * 防線：若仍發現重複 id（例如未來新增的 discovery 規則有疏漏），
+     * 直接丟棄後出現的碰撞 scope 並記錄警告，而非讓 Map 靜默覆蓋。
+     */
+    private assertUniqueScopeIds(scopes: ConfigScope[]): void {
+        const seen = new Set<string>();
+        for (let i = scopes.length - 1; i >= 0; i--) {
+            const id = scopes[i].id;
+            if (seen.has(id)) {
+                console.warn(`VirtualTabs: duplicate ConfigScope id detected, dropping colliding scope "${id}" (type: ${scopes[i].type}, label: ${scopes[i].label})`);
+                scopes.splice(i, 1);
+                continue;
+            }
+            seen.add(id);
+        }
     }
 
     // Save TreeView reference for multi-select management

--- a/src/test/unit/ConfigScopeDiscovery.test.ts
+++ b/src/test/unit/ConfigScopeDiscovery.test.ts
@@ -45,17 +45,6 @@ function discoverScopes(
 ): MockConfigScope[] {
     const scopes: MockConfigScope[] = [];
 
-    if (workspaceFile) {
-        const parentUri = joinPath(workspaceFile, '..');
-        scopes.push({
-            id: parentUri.toString(),
-            type: 'workspace',
-            label: 'Workspace',
-            uri: parentUri,
-            groups: []
-        });
-    }
-
     if (workspaceFolders && workspaceFolders.length > 0) {
         for (const folder of workspaceFolders) {
             scopes.push({
@@ -65,6 +54,26 @@ function discoverScopes(
                 uri: folder.uri,
                 groups: []
             });
+        }
+    }
+
+    if (workspaceFile) {
+        const parentUri = joinPath(workspaceFile, '..');
+        const workspaceScope: MockConfigScope = {
+            id: parentUri.toString(),
+            type: 'workspace',
+            label: 'Workspace',
+            uri: parentUri,
+            groups: []
+        };
+        // self-root .code-workspace：workspace 父目錄與某個 folder 相同時，
+        // 兩者的 id 會是同一個 uri.toString()。若同時保留，provider.ts 以
+        // scope.id 為 key 建立 groupManagers 時，後建立的 GroupManager 會
+        // 靜默覆蓋前一個，導致 loadGroups() 對同一份設定檔重複讀取、每次
+        // 啟動筆數倍增。因此略過該 workspace scope，只保留 folder scope。
+        const isSelfRootAlias = scopes.some(scope => scope.id === workspaceScope.id);
+        if (!isSelfRootAlias) {
+            scopes.unshift(workspaceScope);
         }
     }
 
@@ -175,6 +184,55 @@ describe('ConfigScopeDiscovery 單元測試', () => {
         test('空 workspaceFolders 陣列應回傳空陣列', () => {
             const scopes = discoverScopes(undefined, []);
             expect(scopes).toHaveLength(0);
+        });
+    });
+
+    describe('self-root .code-workspace（workspace 父目錄等於某個 folder）', () => {
+        test('只應回傳一個 folder scope，不應同時保留碰撞的 workspace scope', () => {
+            // "folders": [{ "path": "." }] 的典型情境：
+            // .code-workspace 檔案與唯一的 workspace folder 位於同一目錄
+            const workspaceFile = createMockUri('/home/user/Dawn3GL/Dawn3GL.code-workspace');
+            const folders = [{ uri: createMockUri('/home/user/Dawn3GL'), name: 'Dawn3GL' }];
+            const scopes = discoverScopes(workspaceFile, folders);
+
+            expect(scopes).toHaveLength(1);
+            expect(scopes[0].type).toBe('folder');
+            expect(scopes[0].uri.toString()).toBe(createMockUri('/home/user/Dawn3GL').toString());
+        });
+
+        test('所有 scope id 應唯一（避免 provider.ts 的 groupManagers Map key 碰撞）', () => {
+            const workspaceFile = createMockUri('/home/user/Dawn3GL/Dawn3GL.code-workspace');
+            const folders = [{ uri: createMockUri('/home/user/Dawn3GL'), name: 'Dawn3GL' }];
+            const scopes = discoverScopes(workspaceFile, folders);
+
+            const ids = scopes.map(s => s.id);
+            expect(new Set(ids).size).toBe(ids.length);
+        });
+
+        test('多根工作區中若其中一個 folder 與 workspace 同目錄，仍應保留其餘 folder scope，只略過碰撞的 workspace scope', () => {
+            const workspaceFile = createMockUri('/home/user/Dawn3GL/Dawn3GL.code-workspace');
+            const folders = [
+                { uri: createMockUri('/home/user/Dawn3GL'), name: 'Dawn3GL' },
+                { uri: createMockUri('/home/user/OtherRepo'), name: 'OtherRepo' }
+            ];
+            const scopes = discoverScopes(workspaceFile, folders);
+
+            expect(scopes).toHaveLength(2);
+            expect(scopes.every(s => s.type === 'folder')).toBe(true);
+            const ids = scopes.map(s => s.id);
+            expect(new Set(ids).size).toBe(ids.length);
+        });
+
+        test('workspace 父目錄與所有 folder 都不同時，仍應保留 workspace scope（一般多根工作區行為不受影響）', () => {
+            const workspaceFile = createMockUri('/home/user/workspace/my.code-workspace');
+            const folders = [
+                { uri: createMockUri('/home/user/workspace/Repo-A'), name: 'Repo-A' },
+                { uri: createMockUri('/home/user/workspace/Repo-B'), name: 'Repo-B' }
+            ];
+            const scopes = discoverScopes(workspaceFile, folders);
+
+            expect(scopes).toHaveLength(3);
+            expect(scopes.filter(s => s.type === 'workspace')).toHaveLength(1);
         });
     });
 });


### PR DESCRIPTION
# fix(core): self-root .code-workspace causes ConfigScope id collision → duplicated/doubling groups

## Problem

When a `.code-workspace` file declares only its own directory as the sole folder:

```json
{ "folders": [{ "path": "." }] }
```

(a common "self-root" pattern — e.g. opening `MyProject/MyProject.code-workspace` where `folders` is just `["."]`) — every activation of the extension causes the persisted group data in that project's `.vscode/virtualTab.json` to **double**.

Observed on two independent real projects using this workspace layout: one grew from 41 → 82 top-level-group-entries after a single close/reopen; a second grew similarly. Left unchecked over months of normal use, one file had accumulated to 8× its correct size (7 real groups → 56 duplicated entries). The VS Code tree view then also visually splits into multiple repeated `Project: X` scope headers, each showing the same duplicated group set.

## Root cause

`ConfigScopeDiscovery.discover()` builds:

- one `workspace` scope, `id = uri.toString()` of the `.code-workspace` file's **parent directory**
- one `folder` scope per `vscode.workspace.workspaceFolders[i]`, `id = folder.uri.toString()`

When `folders` is `["."]`, the workspace file's parent directory **is** that single folder, so:

```ts
workspaceScope.id === folderScope.id
```

This breaks the implicit invariant that `ConfigScope.id` is unique within one `discover()` result.

Downstream, `provider.ts` builds `groupManagers: Map<string, GroupManager>` keyed by `scope.id`:

```ts
for (const scope of this.configScopes) {
    const gm = new GroupManager(this.getConfigStorageRoot(scope));
    this.migrateLegacyWorkspaceConfig(scope, gm);
    this.groupManagers.set(scope.id, gm);   // <-- second set() silently overwrites the first
}
```

Because discovery order is workspace-scope-first, then folder-scopes, the second `.set()` (folder manager) silently overwrites the first (workspace manager) — the Map ends up with only **one** manager, pointing at the project's `.vscode/virtualTab.json`, but `configScopes` still has **two** entries with the same id.

`loadGroups()` (no-arg / full reload path) then iterates `configScopes` and does `groupManagers.get(scope.id)` once per scope:

```ts
for (const scope of this.configScopes) {
    const gm = this.groupManagers.get(scope.id); // same key twice → same GroupManager both times
    const { groups: saved } = gm.loadGroups();
    allGroups.push(...saved.map(g => ({ ...g, sourceScopeId: scope.id })));
}
```

Both iterations resolve to the **same** `GroupManager`/file, so the same N persisted groups get read twice into memory (2N). `saveGroupsImmediate()` buckets by `scope.id` the same way, so both scope "buckets" collapse into the same target file, and the doubled 2N gets written straight back to disk. Next activation reads 2N, doubles it to 4N, writes it back — compounding indefinitely.

### Evidence that pinpoints "read twice" rather than "two legitimately different scopes merged"

For one affected project, after reopening once:

| file | total entries | unique ids | notes |
|---|---:|---:|---|
| project `.vscode/virtualTab.json` | 82 | 41 | all 41 ids appear **exactly twice**, each pair byte-identical |
| workspace-scope storage (`globalStorage/.../workspace-config/.vscode/virtualTab.json`) | 41 | 41 | mtime unchanged since first migration |

If this were "workspace-config (41) + folder file (41) legitimately merged", the union would show ~40 overlapping ids plus a couple of scope-unique ones (that's roughly what was observed a layer up, before this precise mechanism was isolated). But the *exact* symptom reproduced live was: every id appearing precisely twice, confirming the same on-disk file was loaded twice in a single `loadGroups()` pass — not two distinct files merging.

## Fix (minimal / hotfix scope)

1. **`src/core/ConfigScopeDiscovery.ts`** — build folder scopes first, then only add the workspace scope if its id doesn't already collide with a folder scope's id (i.e. skip the workspace scope for the self-root alias case, keep the folder scope as sole canonical source):

   ```ts
   static discover(): ConfigScope[] {
       const scopes: ConfigScope[] = [];

       for (const folder of vscode.workspace.workspaceFolders ?? []) {
           scopes.push(ConfigScopeDiscovery.createFolderScope(folder));
       }

       if (vscode.workspace.workspaceFile) {
           const workspaceScope = ConfigScopeDiscovery.createWorkspaceScope(vscode.workspace.workspaceFile);
           const isSelfRootAlias = scopes.some(scope => scope.id === workspaceScope.id);
           if (!isSelfRootAlias) {
               scopes.unshift(workspaceScope);
           }
       }

       return scopes;
   }
   ```

   Ordinary multi-root workspaces (where the `.code-workspace` parent directory differs from every declared folder) are unaffected — the workspace scope is still added, in its original position.

2. **`src/provider.ts`** — defense in depth: a private `assertUniqueScopeIds()` guard runs right after `ConfigScopeDiscovery.discover()` in both the constructor and `reinitializeScopes()`, before `groupManagers` is populated. If a duplicate id is ever found (e.g. from a future discovery rule that reintroduces a collision), it logs a warning and drops the colliding (later) scope rather than letting `Map.set()` silently overwrite — fails safe instead of failing silently.

3. **`src/test/unit/ConfigScopeDiscovery.test.ts`** — added 4 cases: self-root alias collapses to one folder scope; resulting scope ids are unique; a *mixed* multi-root where one folder happens to equal the workspace root still keeps all folder scopes and only skips the colliding workspace scope; and a true multi-root (workspace parent different from every folder) is unaffected.

## What this hotfix intentionally does NOT cover

- No changes to `migrateLegacyWorkspaceConfig()` — it happens to no longer be invoked for the self-root alias case as a side effect of (1) (no workspace-type scope exists for that case anymore), but the function itself is untouched.
- No shared/production-level duplicate-group repair utility for data that's already corrupted on disk (existing users with already-inflated `virtualTab.json` need a one-off manual cleanup, e.g. dedupe-by-`id`, keep-first-occurrence).
- No handling of the pre-existing "orphaned" workspace-config storage files left behind from earlier migrations — those are harmless leftovers, not cleaned up automatically.
- Broader P1 concerns (scoped `(scopeId, groupId)` runtime identity so two *legitimately different* scopes can safely share a group id, optimistic-lock retry correctness, generic multi-root duplicate-id UI handling) are out of scope for this hotfix.

## Verification performed

- `tsc --noEmit` — no errors.
- Full unit suite: 27 suites / 194 tests passing (211 total once the 4 new cases are included in that count... see actual numbers in CI).
- Property-based suite: 4 suites / 13 tests passing.
- Real-world repro: packaged a local test VSIX with only this fix applied, installed over the previously-published version, opened an affected self-root `.code-workspace` project, and did 3 full close/reopen cycles. Group count stayed stable across all 3 (previously it had doubled after just 1 reopen on the same project/version prior to the fix).
