### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the "VirtualTabs" extension will be documented in this file.
 
+## [0.10.0] - Stable Release: Self-Root Workspace Fix & Auto-Group Promotion - 2026-08-16
+
+- **fix(core):** resolve self-root `.code-workspace` `ConfigScope` id collision (#116, contributed by @jianfulin) — when a `.code-workspace` file declares only its own directory as the sole folder (`"folders": [{"path": "."}]`), the workspace scope and folder scope shared the same id, so every activation re-read and re-saved the same `virtualTab.json` twice, doubling group entries on each reopen. `ConfigScopeDiscovery` now skips the redundant workspace scope when it collides with a folder scope, and `provider.ts` adds a defense-in-depth guard against any future duplicate scope id.
+- **Stable Promotion:** promotes the 0.9.0 pre-release fixes to the stable release tier — don't persist auto sub-groups sourced from the built-in "Currently Open Files" group (#99), and avoid a duplicate built-in group entry on scoped `resetToDefault` (#98).
+
 ## [0.9.0] - Built-in Auto-Group Duplicate Persistence Fixes (pre-release) - 2026-07-26
 
 ### 🐛 Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "virtual-tabs",
-    "version": "0.9.0",
+    "version": "0.10.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "virtual-tabs",
-            "version": "0.9.0",
+            "version": "0.10.0",
             "license": "MIT",
             "dependencies": {
                 "fast-glob": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "virtual-tabs",
     "displayName": "VirtualTabs - Virtual File Directories & AI context management",
     "description": "%extension.description%",
-    "version": "0.9.0",
+    "version": "0.10.0",
     "publisher": "winterdrive",
     "icon": "docs/assets/virtualtabs_icon_128.png",
     "categories": [


### PR DESCRIPTION
## Summary
- Promotes the 0.9.0 pre-release fixes to stable (#98, #99)
- Includes the self-root `.code-workspace` `ConfigScope` id collision fix (#116, contributed by @jianfulin)
- Bumps `package.json`/`package-lock.json` to `0.10.0` (even minor → stable publish tier)

## Test plan
- [x] `npm test` (tsc + jest): 207/207 passing
- [x] `npm run test:ui`: 171/172 passing; the 1 timeout (Built-in Group context menu suite) was reproduced in isolation on re-run and passed cleanly (107/107) — confirmed transient/flaky, unrelated to the scope-collision fix