### PR TITLE
test(core): E2E-level regression coverage for self-root ConfigScope collision

### DIFF
--- a/package.json
+++ b/package.json
@@ -687,6 +687,7 @@
         "test:ui:setup": "extest setup-tests",
         "test:ui": "tsc -p tsconfig.test.ui.json && extest setup-and-run \"out/test/ui/**/*.test.js\" -e \".vscode-test/extensions\" -r \"test-resources/multi-root/virtual-tabs.code-workspace\" -c 1.96.0",
         "test:ui:demo": "node src/test/ui/demo/write-demo-settings.cjs && tsc -p tsconfig.test.ui.json && node -e \"const fs=require('fs');const p=require('path').join(require('os').tmpdir(),'test-resources','settings');if(fs.existsSync(p))fs.rmSync(p,{recursive:true,force:true})\" && extest setup-and-run \"out/test/ui/demo/groupOrganize.demo.js\" -e \".vscode-test/extensions\" -r \"test-resources/demo-workspace\" -c 1.96.0 -o \"test-results/demo-vscode-settings.generated.json\"",
+        "test:ui:selfroot": "tsc -p tsconfig.test.ui.json && extest setup-and-run \"out/test/ui/selfRoot/**/*.selfroot.js\" -e \".vscode-test/extensions\" -r \"test-resources/self-root/project.code-workspace\" -c 1.96.0",
         "vscode:prepublish": "npm run build:vt && npm run build:mcp && tsc -p ./ && npm run build:skills",
         "build:mcp": "esbuild mcp-server/src/index.ts --bundle --platform=node --target=node18 --format=cjs --outfile=dist/mcp/index.js --external:vscode",
         "build:vt": "npx tsx scripts/bundle-vt.ts",

--- a/src/test/ui/selfRoot/scopeCollision.selfroot.ts
+++ b/src/test/ui/selfRoot/scopeCollision.selfroot.ts
@@ -1,0 +1,187 @@
+/**
+ * Real E2E test for the self-root .code-workspace ConfigScope collision (#116).
+ *
+ * Unlike selfRootScopeCollisionRegression.test.ts (a jest test with a mocked
+ * `vscode` module), this launches the packaged extension inside a real VS
+ * Code instance opened directly against a self-root .code-workspace
+ * (`"folders": [{ "path": "." }]`), and drives the exact user-facing actions
+ * that triggered the reported bug: toggling the Virtual Tabs view (fires
+ * `refresh(true)`, which persists) and clicking Refresh (calls
+ * `reinitializeScopes()`, which re-discovers scopes). Confirms the persisted
+ * `.vscode/virtualTab.json` group count never grows across repeated cycles,
+ * and that the tree never renders a duplicated scope section.
+ *
+ * Run in isolation via `npm run test:ui:selfroot` — it opens a dedicated
+ * self-root workspace, separate from the shared multi-root fixture the rest
+ * of the `test:ui` suite runs against.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+    ActivityBar,
+    SideBarView,
+    EditorView,
+    VSBrowser,
+    ViewControl
+} from 'vscode-extension-tester';
+import { expect } from 'chai';
+
+const fixtureRoot = path.resolve(__dirname, '../../../../test-resources/self-root');
+const configPath = path.join(fixtureRoot, '.vscode', 'virtualTab.json');
+
+const seedGroups = [{ id: 'self-root-existing', name: 'Self-Root Existing', files: [] }];
+
+function writeConfig(groups: object[]): void {
+    fs.writeFileSync(configPath, `${JSON.stringify(groups, null, 2)}\n`);
+}
+
+function readConfig(): Array<{ id: string; name: string }> {
+    return JSON.parse(fs.readFileSync(configPath, 'utf8'));
+}
+
+async function dismissOnboardingOverlay(): Promise<void> {
+    const driver = VSBrowser.instance.driver;
+    await driver.wait(async () => {
+        return await driver.executeScript(`
+            const styleId = 'vt-e2e-hide-onboarding';
+            if (!document.getElementById(styleId)) {
+                const style = document.createElement('style');
+                style.id = styleId;
+                style.textContent = '.onboarding-a-overlay { display: none !important; }';
+                document.head.appendChild(style);
+            }
+            for (const el of document.querySelectorAll('.onboarding-a-overlay, [aria-label="Welcome to Visual Studio Code"][role="dialog"]')) {
+                el.remove();
+            }
+            return document.querySelectorAll('.onboarding-a-overlay.visible').length === 0;
+        `) as boolean;
+    }, 5_000, 'Onboarding overlay did not disappear');
+}
+
+async function getVisibleTreeLabels(): Promise<string[]> {
+    const driver = VSBrowser.instance.driver;
+    return await driver.executeScript(`
+        return Array.from(document.querySelectorAll('.monaco-list-row'))
+            .map(row => row.textContent ? row.textContent.trim().replace(/\\s+/g, ' ') : '')
+            .filter(Boolean);
+    `) as string[];
+}
+
+async function getVirtualTabsViewControl(): Promise<ViewControl> {
+    const activityBar = new ActivityBar();
+    const viewControl = await VSBrowser.instance.driver.wait(async () => {
+        await dismissOnboardingOverlay();
+        return await activityBar.getViewControl('Virtual Tabs') as ViewControl | undefined;
+    }, 30_000, 'Virtual Tabs icon not found in Activity Bar');
+    if (!viewControl) {
+        throw new Error('Virtual Tabs icon not found in Activity Bar');
+    }
+    return viewControl;
+}
+
+async function openVirtualTabsView(): Promise<SideBarView> {
+    await dismissOnboardingOverlay();
+    const viewControl = await getVirtualTabsViewControl();
+
+    let sidebar: SideBarView;
+    try {
+        sidebar = await viewControl.openView() as SideBarView;
+    } catch {
+        await dismissOnboardingOverlay();
+        await viewControl.getDriver().executeScript('arguments[0].click()', viewControl);
+        sidebar = await new SideBarView().wait();
+    }
+
+    await VSBrowser.instance.driver.wait(async () => {
+        const labels = await getVisibleTreeLabels();
+        return labels.length > 0;
+    }, 30_000, 'Virtual Tabs extension did not activate within 30s');
+
+    return sidebar;
+}
+
+/** Clicking an already-open view's Activity Bar icon collapses/hides it,
+ * firing `onDidChangeVisibility(false)` — the other half of the real
+ * "close and reopen" cycle alongside reinitializeScopes(). */
+async function closeVirtualTabsView(): Promise<void> {
+    const viewControl = await getVirtualTabsViewControl();
+    await viewControl.getDriver().executeScript('arguments[0].click()', viewControl);
+    await VSBrowser.instance.driver.sleep(300);
+}
+
+async function waitForTreeLabel(label: string, timeoutMs = 15_000): Promise<void> {
+    await VSBrowser.instance.driver.wait(async () => {
+        const labels = await getVisibleTreeLabels();
+        return labels.some(t => t.includes(label));
+    }, timeoutMs, `Tree item matching "${label}" not found within ${timeoutMs}ms`);
+}
+
+async function clickToolbarButton(sidebar: SideBarView, titlePattern: RegExp): Promise<void> {
+    const driver = VSBrowser.instance.driver;
+    await driver.wait(async () => {
+        try {
+            const titlePart = sidebar.getTitlePart();
+            const actions = await titlePart.getActions();
+            for (const action of actions) {
+                const title = await action.getTitle();
+                if (titlePattern.test(title)) {
+                    await action.click();
+                    return true;
+                }
+            }
+            return false;
+        } catch (error) {
+            const name = (error as Error).name;
+            if (name === 'StaleElementReferenceError' || name === 'ElementClickInterceptedError') {
+                return false;
+            }
+            throw error;
+        }
+    }, 10_000, `Toolbar button matching "${titlePattern}" not found`);
+}
+
+describe('Self-root .code-workspace — no group doubling across reopen cycles (#116 E2E)', function () {
+    this.timeout(120_000);
+
+    before(async function () {
+        await VSBrowser.instance.waitForWorkbench();
+        await dismissOnboardingOverlay();
+        writeConfig(seedGroups);
+    });
+
+    after(async function () {
+        await new EditorView().closeAllEditors();
+        writeConfig(seedGroups);
+    });
+
+    it('does not grow the persisted group count across repeated close/reopen + refresh cycles', async function () {
+        let sidebar = await openVirtualTabsView();
+        await waitForTreeLabel('Self-Root Existing');
+
+        for (let cycle = 1; cycle <= 3; cycle++) {
+            // Half of the real reopen sequence: hide the view, then show it
+            // again — this fires the treeView.onDidChangeVisibility(true)
+            // listener, which calls provider.refresh(true) and persists
+            // whatever is currently in memory.
+            await closeVirtualTabsView();
+            sidebar = await openVirtualTabsView();
+
+            // The other half: the Refresh button calls
+            // provider.reinitializeScopes(), re-running ConfigScopeDiscovery
+            // against this self-root workspace.
+            await clickToolbarButton(sidebar, /refresh/i);
+            await waitForTreeLabel('Self-Root Existing');
+
+            const persisted = readConfig();
+            expect(persisted, `persisted groups after cycle ${cycle}`).to.have.lengthOf(1);
+            expect(persisted[0].id).to.equal('self-root-existing');
+        }
+
+        // A scope-id collision would also manifest as a duplicated scope
+        // section in the tree — confirm the group renders exactly once.
+        const labels = await getVisibleTreeLabels();
+        const occurrences = labels.filter(l => l.includes('Self-Root Existing')).length;
+        expect(occurrences, `tree rows matching "Self-Root Existing": ${labels.join(' | ')}`).to.equal(1);
+    });
+});

--- a/src/test/ui/selfRoot/scopeCollision.selfroot.ts
+++ b/src/test/ui/selfRoot/scopeCollision.selfroot.ts
@@ -142,9 +142,7 @@ async function clickToolbarButton(sidebar: SideBarView, titlePattern: RegExp): P
 }
 
 describe('Self-root .code-workspace — no group doubling across reopen cycles (#116 E2E)', function () {
-    // Generous enough to cover VT_E2E_KEEP_OPEN/VT_E2E_KEEP_OPEN_MS pausing at
-    // the end for manual inspection, on top of the normal ~10s run time.
-    this.timeout(15 * 60_000);
+    this.timeout(120_000);
 
     before(async function () {
         await VSBrowser.instance.waitForWorkbench();
@@ -185,14 +183,5 @@ describe('Self-root .code-workspace — no group doubling across reopen cycles (
         const labels = await getVisibleTreeLabels();
         const occurrences = labels.filter(l => l.includes('Self-Root Existing')).length;
         expect(occurrences, `tree rows matching "Self-Root Existing": ${labels.join(' | ')}`).to.equal(1);
-
-        // Set VT_E2E_KEEP_OPEN=1 to pause here after all assertions pass, so
-        // the VS Code window stays up for manual visual inspection instead
-        // of being closed immediately by the test runner.
-        const pauseMs = Number(process.env.VT_E2E_KEEP_OPEN_MS) || (process.env.VT_E2E_KEEP_OPEN ? 5 * 60_000 : 0);
-        if (pauseMs > 0) {
-            console.log(`VT_E2E_KEEP_OPEN set — leaving the VS Code window open for ${Math.round(pauseMs / 1000)}s for manual inspection...`);
-            await VSBrowser.instance.driver.sleep(pauseMs);
-        }
     });
 });

--- a/src/test/ui/selfRoot/scopeCollision.selfroot.ts
+++ b/src/test/ui/selfRoot/scopeCollision.selfroot.ts
@@ -142,7 +142,9 @@ async function clickToolbarButton(sidebar: SideBarView, titlePattern: RegExp): P
 }
 
 describe('Self-root .code-workspace — no group doubling across reopen cycles (#116 E2E)', function () {
-    this.timeout(120_000);
+    // Generous enough to cover VT_E2E_KEEP_OPEN/VT_E2E_KEEP_OPEN_MS pausing at
+    // the end for manual inspection, on top of the normal ~10s run time.
+    this.timeout(15 * 60_000);
 
     before(async function () {
         await VSBrowser.instance.waitForWorkbench();
@@ -183,5 +185,14 @@ describe('Self-root .code-workspace — no group doubling across reopen cycles (
         const labels = await getVisibleTreeLabels();
         const occurrences = labels.filter(l => l.includes('Self-Root Existing')).length;
         expect(occurrences, `tree rows matching "Self-Root Existing": ${labels.join(' | ')}`).to.equal(1);
+
+        // Set VT_E2E_KEEP_OPEN=1 to pause here after all assertions pass, so
+        // the VS Code window stays up for manual visual inspection instead
+        // of being closed immediately by the test runner.
+        const pauseMs = Number(process.env.VT_E2E_KEEP_OPEN_MS) || (process.env.VT_E2E_KEEP_OPEN ? 5 * 60_000 : 0);
+        if (pauseMs > 0) {
+            console.log(`VT_E2E_KEEP_OPEN set — leaving the VS Code window open for ${Math.round(pauseMs / 1000)}s for manual inspection...`);
+            await VSBrowser.instance.driver.sleep(pauseMs);
+        }
     });
 });

--- a/src/test/unit/selfRootScopeCollisionRegression.test.ts
+++ b/src/test/unit/selfRootScopeCollisionRegression.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Integration regression test for the self-root .code-workspace ConfigScope
+ * id collision (#116).
+ *
+ * ConfigScopeDiscovery.test.ts only exercises a hand-mirrored copy of the
+ * discover() logic — it never calls the real TempFoldersProvider code path
+ * that actually persists data, so it can't catch a regression in how
+ * reinitializeScopes()/loadGroups()/saveGroupsImmediate() route through
+ * groupManagers by scope.id. That's exactly the path that doubled real
+ * users' virtualTab.json on every reopen before the fix (41 -> 82 entries
+ * after a single reopen, reported live).
+ *
+ * This test drives the real discover() -> reinitializeScopes() -> real
+ * GroupManager file I/O -> saveGroupsImmediate() pipeline against a real
+ * temp directory across several simulated close/reopen cycles, and asserts
+ * the persisted group count never grows.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { pathToFileURL } from 'url';
+import type { TempGroup } from '../../types';
+
+jest.mock('vscode', () => {
+    class Uri {
+        private constructor(public readonly fsPath: string) { }
+
+        static file(fsPath: string): Uri {
+            return new Uri(path.resolve(fsPath));
+        }
+
+        static parse(value: string): Uri {
+            if (value.startsWith('file://')) {
+                return new Uri(new URL(value).pathname);
+            }
+            return new Uri(value);
+        }
+
+        static joinPath(base: Uri, ...segments: string[]): Uri {
+            return new Uri(path.join(base.fsPath, ...segments));
+        }
+
+        toString(): string {
+            return pathToFileURL(this.fsPath).toString();
+        }
+    }
+
+    return {
+        Uri,
+        TreeItem: class {
+            collapsibleState?: number;
+            constructor(public readonly label: unknown, collapsibleState?: number) {
+                this.collapsibleState = collapsibleState;
+            }
+        },
+        TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+        EventEmitter: class {
+            event = jest.fn();
+            fire = jest.fn();
+        },
+        ThemeIcon: Object.assign(
+            class { constructor(public readonly id: string, public readonly color?: unknown) { } },
+            { File: { id: 'file' } }
+        ),
+        ThemeColor: class { constructor(public readonly id: string) { } },
+        commands: { executeCommand: jest.fn() },
+        window: {
+            tabGroups: { all: [] },
+            showErrorMessage: jest.fn(),
+            showInformationMessage: jest.fn()
+        },
+        workspace: { workspaceFolders: [] as unknown[], workspaceFile: undefined as unknown }
+    };
+}, { virtual: true });
+
+import * as vscode from 'vscode';
+import { TempFoldersProvider } from '../../provider';
+import { GroupManager } from '../../core/GroupManager';
+import type { ConfigScope } from '../../types';
+
+function makeSelfRootProject(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'vt-self-root-'));
+}
+
+function seedConfig(projectDir: string, groups: TempGroup[]): string {
+    const configPath = path.join(projectDir, '.vscode', 'virtualTab.json');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify(groups, null, 2));
+    return configPath;
+}
+
+/** Bare provider instance bypassing the constructor, mirroring the harness
+ * pattern already used in autoGroupProviderRegression.test.ts. */
+function createReloadHarness(): TempFoldersProvider {
+    const provider = Object.create(TempFoldersProvider.prototype) as TempFoldersProvider;
+    provider.groups = [];
+    provider.configScopes = [];
+    (provider as unknown as { scopeOrderIds: string[] }).scopeOrderIds = [];
+    (provider as unknown as { activeScopeIds: Set<string> }).activeScopeIds = new Set();
+    (provider as unknown as { expandedScopeIds: Set<string> }).expandedScopeIds = new Set();
+    (provider as unknown as { groupManagers: Map<string, unknown> }).groupManagers = new Map();
+    (provider as unknown as { loadedVersions: Map<string, number> }).loadedVersions = new Map();
+    (provider as unknown as { _onDidChangeTreeData: { fire: jest.Mock } })._onDidChangeTreeData = { fire: jest.fn() };
+    return provider;
+}
+
+/** Simulates one full "close VS Code, reopen the same self-root workspace" cycle. */
+function simulateReopenCycle(provider: TempFoldersProvider): void {
+    provider.reinitializeScopes();
+    // Some later user action (opening/closing a file, etc.) triggers a
+    // default refresh(true), which schedules the debounced persist.
+    provider.refresh(true);
+    provider.flushPendingSave();
+}
+
+describe('Self-root .code-workspace ConfigScope collision (#116 regression)', () => {
+    let projectDir: string;
+
+    beforeEach(() => {
+        projectDir = makeSelfRootProject();
+        (vscode.workspace as unknown as { workspaceFile: unknown }).workspaceFile =
+            vscode.Uri.file(path.join(projectDir, 'project.code-workspace'));
+        (vscode.workspace as unknown as { workspaceFolders: unknown[] }).workspaceFolders = [
+            { uri: vscode.Uri.file(projectDir), name: path.basename(projectDir), index: 0 }
+        ];
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        fs.rmSync(projectDir, { recursive: true, force: true });
+        (vscode.workspace as unknown as { workspaceFile: unknown }).workspaceFile = undefined;
+        (vscode.workspace as unknown as { workspaceFolders: unknown[] }).workspaceFolders = [];
+    });
+
+    test('fixed discover(): 5 reopen cycles never grow the persisted group count', () => {
+        const configPath = seedConfig(projectDir, [{ id: 'g1', name: 'Existing Group', files: [] }]);
+        const provider = createReloadHarness();
+
+        for (let cycle = 1; cycle <= 5; cycle++) {
+            simulateReopenCycle(provider);
+
+            // Exactly one real scope should survive the self-root collision.
+            expect(provider.configScopes).toHaveLength(1);
+            expect(provider.configScopes[0].type).toBe('folder');
+
+            const persisted = JSON.parse(fs.readFileSync(configPath, 'utf8')) as TempGroup[];
+            expect(persisted).toHaveLength(1);
+            expect(persisted[0].id).toBe('g1');
+        }
+    });
+
+    test('regression check: an id collision that reaches groupManagers still doubles the group on save (isolates the original root cause)', () => {
+        // This bypasses ConfigScopeDiscovery.discover() and the new
+        // assertUniqueScopeIds() guard entirely (both now prevent the
+        // collision from ever reaching this point) so the test isolates the
+        // original root cause: groupManagers.set(scope.id, ...) silently
+        // overwrites on a duplicate id, but loadGroups()/saveGroupsImmediate()
+        // still iterate the configScopes ARRAY, which has two entries for
+        // that one id — reading/writing the same real file twice.
+        const configPath = seedConfig(projectDir, [{ id: 'g1', name: 'Existing Group', files: [] }]);
+        const provider = createReloadHarness();
+
+        const collidingId = vscode.Uri.file(projectDir).toString();
+        const collidingScopes: ConfigScope[] = [
+            { id: collidingId, type: 'workspace', label: 'Workspace', uri: vscode.Uri.file(projectDir), groups: [] },
+            { id: collidingId, type: 'folder', label: path.basename(projectDir), uri: vscode.Uri.file(projectDir), groups: [] }
+        ];
+        provider.configScopes = collidingScopes;
+        const groupManagers = (provider as unknown as { groupManagers: Map<string, GroupManager> }).groupManagers;
+        for (const scope of collidingScopes) {
+            groupManagers.set(scope.id, new GroupManager(scope.uri.fsPath));
+        }
+
+        (provider as unknown as { loadGroups: () => boolean }).loadGroups();
+        provider.refresh(true);
+        provider.flushPendingSave();
+
+        const persisted = JSON.parse(fs.readFileSync(configPath, 'utf8')) as TempGroup[];
+        expect(persisted.length).toBeGreaterThan(1);
+        expect(persisted.filter(g => g.id === 'g1')).toHaveLength(2);
+    });
+});

--- a/test-resources/self-root/.vscode/virtualTab.json
+++ b/test-resources/self-root/.vscode/virtualTab.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": "self-root-existing",
+    "name": "Self-Root Existing",
+    "files": [],
+    "bookmarks": {}
+  }
+]

--- a/test-resources/self-root/project.code-workspace
+++ b/test-resources/self-root/project.code-workspace
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "workbench.startupEditor": "none"
+  }
+}


### PR DESCRIPTION
## Summary
- `ConfigScopeDiscovery.test.ts` (added in #116) only tests a hand-mirrored copy of `discover()`'s logic — it never calls the real `TempFoldersProvider` code path that actually persists data, so it wouldn't catch a regression in how `reinitializeScopes()` / `loadGroups()` / `saveGroupsImmediate()` route through `groupManagers` by `scope.id`.
- **Jest-level integration test** (`selfRootScopeCollisionRegression.test.ts`): drives the real `discover()` → `reinitializeScopes()` → real `GroupManager` file I/O → `saveGroupsImmediate()` pipeline against a real temp directory across 5 simulated close/reopen cycles, asserting the persisted group count never grows. Also includes a regression check that isolates the original root cause (`groupManagers` Map overwrite + `configScopes` array duplication) independent of the new `assertUniqueScopeIds()` guard.
- **Real E2E test** (`scopeCollision.selfroot.ts`, run via new `npm run test:ui:selfroot` script): launches the packaged extension against a dedicated self-root `.code-workspace` fixture in a real VS Code instance, toggles the Virtual Tabs view + clicks Refresh across 3 cycles, and asserts the persisted `virtualTab.json` never grows and the tree never renders a duplicated scope section.

## Test plan
- [x] Verified the jest test **fails** against the pre-#116 code (temporarily reverted `ConfigScopeDiscovery.ts`/`provider.ts` to the commit before #116 — group count went 1 → 2 after one simulated reopen cycle), then restored the fix and confirmed it passes again.
- [x] `npm test`: 32/32 suites, 209/209 tests passing with the new file included.
- [x] `npm run test:ui:selfroot`: 1/1 passing against a real VS Code instance.