### PR TITLE
[Routine - VT] fix(provider): use path.extname for addAutoGroupsByExt, not filename split

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1435,7 +1435,8 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
         for (const uriStr of group.files) {
             try {
                 const uri = vscode.Uri.parse(uriStr);
-                const ext = uri.fsPath.split('.').pop()?.toLowerCase() || 'other';
+                const rawExt = path.extname(uri.fsPath).toLowerCase();
+                const ext = rawExt ? rawExt.slice(1) : 'no-extension';
                 if (!extMap[ext]) extMap[ext] = [];
                 extMap[ext].push(uriStr);
             } catch { }

--- a/src/test/unit/autoGroupProviderRegression.test.ts
+++ b/src/test/unit/autoGroupProviderRegression.test.ts
@@ -159,6 +159,26 @@ describe('TempFoldersProvider auto-group commands (real provider.ts code path)',
         expect(mdGroup?.bookmarks?.[mdFile]).toEqual([{ id: 'bm-2', line: 1, label: 'md bookmark', created: 2 }]);
     });
 
+    test('addAutoGroupsByExt buckets extension-less files together instead of one group per filename', () => {
+        const makefile = pathToFileURL(path.join(workspaceDir, 'Makefile')).toString();
+        const dockerfile = pathToFileURL(path.join(workspaceDir, 'Dockerfile')).toString();
+
+        const group: TempGroup = {
+            id: 'group-1',
+            name: 'Source',
+            files: [makefile, dockerfile]
+        };
+
+        const provider = createProviderHarness([group], []);
+        selectGroup(provider, 0, group);
+
+        provider.addAutoGroupsByExt();
+
+        const autoGroups = provider.groups.filter(g => g.id !== group.id);
+        expect(autoGroups).toHaveLength(1);
+        expect(autoGroups[0].files).toEqual(expect.arrayContaining([makefile, dockerfile]));
+    });
+
     test('autoGroupByModifiedDate moves bookmarks to the new date sub-groups', () => {
         const filePath = path.join(workspaceDir, 'today.ts');
         fs.writeFileSync(filePath, 'export {};');


### PR DESCRIPTION
## 1. Pre-flight Check

- Open PRs: only #119 `chore: release v0.11.0` (`release/v0.11.0-260816` → `main`), touching `CHANGELOG.md`, `package.json`, `package-lock.json` only (release metadata, no source code).
- Active routine/feature branches on `origin` (from `git branch -r`): a long tail of already-landed `routine/vt-fix-*` branches (autogroup-bookmarks, autogrouper-bookmark-key, bookmark-relpath, bookmark-stale-groupidx, copygroupname-i18n, corrupted-config-backup, dragdrop-bookmark-key, duplicate-scope, fileentrymatcher-malformed-uri, filemanager-relpath, filesorter-tests, flush-pending-save, groupmanager-nonarray-json, groupmgr-cache-miss, i18n-dollar-placeholder, isdescendant-cycle-guard, jumptobookmark-clamp, mcp-workspace-poll, projectexplorer-maxresults, remove-dead-getfilesindirectory, savegroups-silent-error, scope-description-stale, scopeheader-foldername, senddestguard, sendto-malformed-target, skillgen-error-handling, treeview-listener-disposal, validatejson-nonobject-element, validatejson-undefined-files, watcher-new-scope, watcher-stale-scope), plus a `chore/release-gate-label-only` and `revert/routine-infra-ci` branch, and several `release/*` branches. None of these are open PRs, and none touch `provider.ts`'s `addAutoGroupsByExt` extension-extraction logic.
- No `AGENTS.md` present in repo root.
- **No overlap**: this PR only touches the extension-name parsing inside `TempFoldersProvider.addAutoGroupsByExt()` in `src/provider.ts`, a narrow logic bug not covered by any of the above.

## 2. Changes

`addAutoGroupsByExt()` (the "Auto Group by Extension" tree view command) derived a file's "extension" via `uri.fsPath.split('.').pop()`. For extension-less filenames such as `Makefile` or `Dockerfile` (no `.` at all), `split('.').pop()` returns the **entire filename** instead of a real extension, so each such file spawned its own separate auto sub-group (e.g. `Auto: .makefile @ Source`, `Auto: .dockerfile @ Source`) instead of being bucketed together — defeating the point of the feature. The MCP-tool equivalent, `AutoGrouper.groupByExtension` in `src/core/AutoGrouper.ts`, already handled this correctly via `path.extname(...)` with a `'no-extension'` fallback.

Fix: use `path.extname(uri.fsPath).toLowerCase()` (mirroring the already-correct `core/AutoGrouper.ts` logic) and fall back to a shared `'no-extension'` bucket key when there is no dot, instead of using the raw filename as a pseudo-extension. `path` was already imported in `provider.ts`.

Added a regression test in `src/test/unit/autoGroupProviderRegression.test.ts` asserting that `Makefile` and `Dockerfile` land in a single shared auto group rather than two separate ones.

Confirms this PR does **not**:
- add/rename/delete any VS Code command registration
- add/rename/delete any `package.json` contributed configuration key
- touch dependencies, `package.json`, or `package-lock.json`
- modify tab-group serialization format or config storage/migration logic

## 3. Safety Verification

Commands run locally, in order:

```
npx tsc -p ./
```
Result: passed, no errors.

```
npm run test
```
(runs `tsc -p ./ && jest --runInBand`)
Result: **35 test suites passed, 226 tests passed**, 0 failed (includes the new regression test).

No `lint` or `format:check` script exists in `package.json`, so those steps were skipped per the routine's own instructions.

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` consolidation are intentionally deferred to the weekend release/integration PR and are **not** included here. If CI fails solely due to the repository's version-bump/release-readiness gate, that is expected behavior for a routine PR, not a code validation failure.