### PR TITLE
[Routine - VT] fix(commands): guard bookmark edit/remove handlers against stale groupIdx

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1235,6 +1235,9 @@ export function registerCommands(
             }
 
             const group = provider.groups[item.groupIdx];
+            if (!group) {
+                return;
+            }
             const updatedBookmark = BookmarkManager.updateLabel(item.bookmark, newLabel);
 
             BookmarkManager.updateBookmarkInGroup(
@@ -1269,6 +1272,9 @@ export function registerCommands(
             }
 
             const group = provider.groups[item.groupIdx];
+            if (!group) {
+                return;
+            }
             const updatedBookmark = BookmarkManager.updateDescription(
                 item.bookmark,
                 newDescription || undefined
@@ -1296,6 +1302,9 @@ export function registerCommands(
             }
 
             const group = provider.groups[item.groupIdx];
+            if (!group) {
+                return;
+            }
             const removed = BookmarkManager.removeBookmarkFromGroup(
                 group,
                 item.fileUri.toString(),


### PR DESCRIPTION
## Pre-flight Check

Open PRs checked (Phase 1):
- #121 `routine/vt-fix-getscopelabel-basename-260817` — touches `src/provider.ts` (`getScopeLabel`), `src/test/unit/getScopeLabel.test.ts`
- #120 `routine/vt-fix-autogroupbyext-noext-260816` — touches `src/provider.ts` (`addAutoGroupsByExt`), `src/test/unit/autoGroupProviderRegression.test.ts`

This PR does not overlap: it only touches `src/commands.ts` (three bookmark command handlers), and never touches `src/provider.ts` or the `getScopeLabel`/`addAutoGroupsByExt` functions modified by #121/#120.

## Changes

`virtualTabs.editBookmarkLabel`, `virtualTabs.editBookmarkDescription`, and `virtualTabs.removeBookmark` in [src/commands.ts](src/commands.ts) looked up `provider.groups[item.groupIdx]` and passed the result straight into `BookmarkManager.updateBookmarkInGroup` / `removeBookmarkFromGroup` without checking for `undefined`. Those `BookmarkManager` methods unconditionally dereference `group.bookmarks`, so if the group at `groupIdx` was removed or reordered between when the tree item was rendered and when the command actually ran, the command threw an uncaught `TypeError` instead of silently no-oping.

Added the same `if (!group) { return; }` guard already used by nearby handlers in the same file (e.g. `duplicateGroup`, `openAllFiles`, `closeAllFiles`).

This PR does **not** modify command registrations, contributed configuration keys (`package.json`), dependencies, or the tab-group serialization/storage format — it only adds a defensive early-return inside three existing command bodies.

## Safety Verification

Commands run locally, all passed:
- `npx tsc -p ./` — no errors
- `npm run test` (`tsc -p ./ && jest --runInBand`) — 35 suites / 225 tests passed

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and CHANGELOG consolidation are intentionally deferred to the weekend release/integration PR. If CI fails only due to the repository's version-bump/release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)