### PR TITLE
[Routine - VT] fix(dragAndDrop): use bitwise FileType checks so symlinks aren't dropped

### DIFF
--- a/src/dragAndDrop.ts
+++ b/src/dragAndDrop.ts
@@ -127,11 +127,15 @@ export class TempFoldersDragAndDropController implements vscode.TreeDragAndDropC
                         const uri = this.toDroppedUri(uriStr);
                         const stat = await vscode.workspace.fs.stat(uri);
 
-                        if (stat.type === vscode.FileType.Directory) {
+                        // vscode.FileType is a bitmask (e.g. a symlinked directory reports
+                        // Directory | SymbolicLink), so strict equality would silently skip
+                        // symlinks. Use bitwise checks, testing Directory first since a path
+                        // can't be both.
+                        if ((stat.type & vscode.FileType.Directory) !== 0) {
                             // It's a directory - recursively get all files
                             const filesInDir = await this.getFilesInDirectoryRecursive(uri);
                             allFileUris.push(...filesInDir.map(f => f.toString()));
-                        } else if (stat.type === vscode.FileType.File) {
+                        } else if ((stat.type & vscode.FileType.File) !== 0) {
                             // It's a file - add directly
                             allFileUris.push(uri.toString());
                         }
@@ -413,11 +417,24 @@ export class TempFoldersDragAndDropController implements vscode.TreeDragAndDropC
         return files;
     }
 
+    // A symlinked directory that (directly or indirectly) contains itself would
+    // otherwise recurse forever, since each recursive call joins a new, ever-growing
+    // path segment onto the URI rather than repeating a previously seen one.
+    private static readonly MAX_RECURSIVE_DROP_DEPTH = 50;
+
     /**
      * Recursively get all files in a directory
      */
-    private async getFilesInDirectoryRecursive(dirUri: vscode.Uri): Promise<vscode.Uri[]> {
+    private async getFilesInDirectoryRecursive(
+        dirUri: vscode.Uri,
+        depth: number = 0
+    ): Promise<vscode.Uri[]> {
         const files: vscode.Uri[] = [];
+
+        if (depth >= TempFoldersDragAndDropController.MAX_RECURSIVE_DROP_DEPTH) {
+            console.error(`Directory nesting too deep (possible symlink cycle), stopping at: ${dirUri.fsPath}`);
+            return files;
+        }
 
         try {
             const entries = await vscode.workspace.fs.readDirectory(dirUri);
@@ -425,9 +442,10 @@ export class TempFoldersDragAndDropController implements vscode.TreeDragAndDropC
             for (const [name, type] of entries) {
                 const entryUri = vscode.Uri.joinPath(dirUri, name);
 
-                if (type === vscode.FileType.File) {
-                    files.push(entryUri);
-                } else if (type === vscode.FileType.Directory) {
+                // vscode.FileType is a bitmask (e.g. a symlinked directory reports
+                // Directory | SymbolicLink), so strict equality would silently skip
+                // symlinked entries. Use bitwise checks instead.
+                if ((type & vscode.FileType.Directory) !== 0) {
                     // Skip hidden directories (names starting with '.') such as .git, .github
                     // to match VS Code's native tree view behavior.
                     // Hidden files (e.g. .gitignore, .editorconfig) are still included.
@@ -435,8 +453,10 @@ export class TempFoldersDragAndDropController implements vscode.TreeDragAndDropC
                         continue;
                     }
                     // Recursively get files from subdirectory
-                    const subFiles = await this.getFilesInDirectoryRecursive(entryUri);
+                    const subFiles = await this.getFilesInDirectoryRecursive(entryUri, depth + 1);
                     files.push(...subFiles);
+                } else if ((type & vscode.FileType.File) !== 0) {
+                    files.push(entryUri);
                 }
             }
         } catch (e) {

--- a/src/test/unit/dragAndDropSymlinkFileType.test.ts
+++ b/src/test/unit/dragAndDropSymlinkFileType.test.ts
@@ -1,0 +1,102 @@
+/**
+ * 單元測試：外部拖曳檔案時，FileType 位元遮罩（bitmask）判斷邏輯
+ *
+ * vscode.FileType 為位元遮罩（bitmask），符號連結（symlink）的檔案/資料夾
+ * 會回傳 File|SymbolicLink 或 Directory|SymbolicLink 的組合值。
+ * 若使用嚴格相等（===）比對 FileType.File / FileType.Directory，
+ * 符號連結會被靜默略過，導致使用者拖入的檔案憑空消失。
+ * 本測試驗證改用位元運算（&）後，符號連結能被正確辨識，
+ * 並驗證遞迴深度上限可防止自我參照符號連結造成無窮遞迴。
+ */
+
+// ─── 模擬 vscode.FileType 位元遮罩 ──────────────────────────────────────────
+
+const FileType = {
+    Unknown: 0,
+    File: 1,
+    Directory: 2,
+    SymbolicLink: 64
+};
+
+const MAX_RECURSIVE_DROP_DEPTH = 50;
+
+interface FakeEntry {
+    name: string;
+    type: number;
+    children?: FakeEntry[];
+}
+
+/**
+ * 模擬 getFilesInDirectoryRecursive 修正後的核心判斷邏輯：
+ * 使用位元運算辨識 File / Directory，並以深度上限防止符號連結循環造成的無窮遞迴。
+ */
+function getFilesRecursive(entries: FakeEntry[], parentPath = '', depth = 0): string[] {
+    if (depth >= MAX_RECURSIVE_DROP_DEPTH) {
+        return [];
+    }
+
+    const files: string[] = [];
+
+    for (const entry of entries) {
+        const fullPath = parentPath ? `${parentPath}/${entry.name}` : entry.name;
+
+        if ((entry.type & FileType.Directory) !== 0) {
+            if (entry.name.startsWith('.')) {
+                continue;
+            }
+            if (entry.children) {
+                const subFiles = getFilesRecursive(entry.children, fullPath, depth + 1);
+                files.push(...subFiles);
+            }
+        } else if ((entry.type & FileType.File) !== 0) {
+            files.push(fullPath);
+        }
+    }
+
+    return files;
+}
+
+// ─── 測試 ─────────────────────────────────────────────────────────────────────
+
+describe('外部拖曳檔案時符號連結（symlink）的 FileType 判斷', () => {
+    test('symlink 指向的檔案（File|SymbolicLink）應被視為檔案', () => {
+        const entries: FakeEntry[] = [
+            { name: 'linked-file.ts', type: FileType.File | FileType.SymbolicLink }
+        ];
+
+        const result = getFilesRecursive(entries);
+        expect(result).toContain('linked-file.ts');
+    });
+
+    test('symlink 指向的資料夾（Directory|SymbolicLink）應被視為資料夾並遞迴展開', () => {
+        const entries: FakeEntry[] = [
+            {
+                name: 'linked-dir',
+                type: FileType.Directory | FileType.SymbolicLink,
+                children: [{ name: 'inner.ts', type: FileType.File }]
+            }
+        ];
+
+        const result = getFilesRecursive(entries);
+        expect(result).toEqual(['linked-dir/inner.ts']);
+    });
+
+    test('一般檔案與資料夾（無 SymbolicLink 位元）行為維持不變', () => {
+        const entries: FakeEntry[] = [
+            { name: 'plain.ts', type: FileType.File },
+            { name: 'src', type: FileType.Directory, children: [{ name: 'index.ts', type: FileType.File }] }
+        ];
+
+        const result = getFilesRecursive(entries);
+        expect(result).toEqual(['plain.ts', 'src/index.ts']);
+    });
+
+    test('自我參照的符號連結資料夾不應造成無窮遞迴（受深度上限保護）', () => {
+        const cyclicDir: FakeEntry = { name: 'self-link', type: FileType.Directory | FileType.SymbolicLink };
+        cyclicDir.children = [cyclicDir];
+
+        // Should terminate (not stack-overflow / hang) once MAX_RECURSIVE_DROP_DEPTH is hit.
+        expect(() => getFilesRecursive([cyclicDir])).not.toThrow();
+        expect(getFilesRecursive([cyclicDir])).toEqual([]);
+    });
+});


### PR DESCRIPTION
## 1. Pre-flight Check

Open PRs / active routine branches checked in Phase 1:
- #123 `docs/testing-guide-260819` — touches `docs/TESTING.md`, `docs/TESTING.zh-TW.md`
- #122 `routine/vt-fix-stale-groupidx-bookmark-cmds-260818` — touches `src/commands.ts`
- #121 `routine/vt-fix-getscopelabel-basename-260817` — touches `src/provider.ts`, `src/test/unit/getScopeLabel.test.ts`
- #120 `routine/vt-fix-autogroupbyext-noext-260816` — touches `src/provider.ts`, `src/test/unit/autoGroupProviderRegression.test.ts`

This PR only touches `src/dragAndDrop.ts` (plus a new, additive test file), which none of the above PRs modify, so there is no overlap.

## 2. Changes

`vscode.FileType` is a bitmask, not an enum with mutually-exclusive values — a symlinked file reports `File | SymbolicLink` and a symlinked directory reports `Directory | SymbolicLink`. `src/dragAndDrop.ts` compared `stat.type` / entry `type` against `vscode.FileType.File` / `vscode.FileType.Directory` with strict equality (`===`) in two places:

- `handleDrop` (external drag-and-drop of files/folders from outside VS Code)
- `getFilesInDirectoryRecursive` (recursive directory expansion for a dropped folder)

Because the combined bitmask value never strictly equals the plain constant, any symlinked file or folder dropped onto the VirtualTabs panel (or nested inside a dropped folder) was silently skipped — it just didn't show up in the group, with no error message.

Fix: switch both checks to bitwise (`(type & vscode.FileType.Directory) !== 0`, checking Directory first since a path can't be both). Since directories are now actually traversed through symlinks, added a recursion depth cap (`MAX_RECURSIVE_DROP_DEPTH = 50`) in `getFilesInDirectoryRecursive` to guard against a self-referential symlink causing unbounded recursion (a plain "visited by URI string" set would not catch this, since each recursive call joins a new, ever-growing path segment rather than repeating an already-seen URI).

Also added `src/test/unit/dragAndDropSymlinkFileType.test.ts`, following the existing `dragAndDropHiddenFiles.test.ts` pattern (mimics the core bitmask/recursion logic against fake directory structures rather than mocking `vscode.workspace.fs`), covering:
- symlinked file recognized as a file
- symlinked directory recognized as a directory and recursed into
- plain files/directories behave unchanged
- a self-referential symlinked directory terminates instead of infinitely recursing

This PR does **not** modify any VS Code command registrations, contributed configuration keys (`package.json`), dependencies, or the tab-group serialization/storage format.

## 3. Safety Verification

Commands run locally, all passed:
- `npx tsc -p ./` — no type errors
- `npm run test` (`tsc -p ./ && jest --runInBand`) — 36 suites / 229 tests passed

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` updates are intentionally deferred to the weekend release/integration PR. If CI fails only due to the repository's version-bump/release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.