### PR TITLE
[Routine - VT] fix(core): remove orphaned bookmarks when removeFilesFromGroup drops a file

### DIFF
--- a/src/core/FileManager.ts
+++ b/src/core/FileManager.ts
@@ -135,7 +135,23 @@ export class FileManager {
       } else {
         group.files.splice(index, 1);
         result.removed.push(filePath);
+
+        // Keep bookmarks in sync with group membership: an orphaned bookmark
+        // for a file no longer in the group would otherwise persist in the
+        // config file indefinitely (the VS Code UI removal path already does
+        // this via GroupFileRemoval; this MCP-driven path needs its own copy).
+        if (group.bookmarks) {
+          for (const bookmarkKey of Object.keys(group.bookmarks)) {
+            if (matchesStoredFileEntry(bookmarkKey, fileUri, targetFsPath, workspaceRoot)) {
+              delete group.bookmarks[bookmarkKey];
+            }
+          }
+        }
       }
+    }
+
+    if (group.bookmarks && Object.keys(group.bookmarks).length === 0) {
+      delete group.bookmarks;
     }
 
     if (result.removed.length > 0) {

--- a/src/test/unit/fileManagerRelpath.test.ts
+++ b/src/test/unit/fileManagerRelpath.test.ts
@@ -68,4 +68,42 @@ describe('FileManager relative-path membership', () => {
         expect(result.removed).toEqual([]);
         expect(result.notFound).toEqual([path.join(tmpDir, 'src', 'missing.ts')]);
     });
+
+    test('removeFilesFromGroup deletes bookmarks stored under the removed file so they do not linger orphaned', () => {
+        const { fm, gm } = setupWorkspace([{
+            id: 'group-1',
+            name: 'Test Group',
+            files: ['src/foo.ts', 'src/bar.ts'],
+            bookmarks: {
+                'src/foo.ts': [{ id: 'bm-1', line: 3, label: 'note', created: 1 }],
+                'src/bar.ts': [{ id: 'bm-2', line: 5, label: 'keep', created: 1 }]
+            }
+        }]);
+
+        const result = fm.removeFilesFromGroup('group-1', [path.join(tmpDir, 'src', 'foo.ts')]);
+
+        expect(result.removed).toEqual([path.join(tmpDir, 'src', 'foo.ts')]);
+
+        const { groups } = gm.loadGroups();
+        expect(groups[0].files).toEqual(['src/bar.ts']);
+        expect(groups[0].bookmarks).toEqual({
+            'src/bar.ts': [{ id: 'bm-2', line: 5, label: 'keep', created: 1 }]
+        });
+    });
+
+    test('removeFilesFromGroup clears the bookmarks field entirely once the last bookmark is removed', () => {
+        const { fm, gm } = setupWorkspace([{
+            id: 'group-1',
+            name: 'Test Group',
+            files: ['src/foo.ts'],
+            bookmarks: {
+                'src/foo.ts': [{ id: 'bm-1', line: 3, label: 'note', created: 1 }]
+            }
+        }]);
+
+        fm.removeFilesFromGroup('group-1', [path.join(tmpDir, 'src', 'foo.ts')]);
+
+        const { groups } = gm.loadGroups();
+        expect(groups[0].bookmarks).toBeUndefined();
+    });
 });


### PR DESCRIPTION
## 1. Pre-flight Check

Open PRs / active branches checked (2026-08-20):
- #125 `fix/builtin-group-autosync` — touches `src/extension.ts`, `src/provider.ts`
- #124 `routine/vt-fix-dragdrop-symlink-filetype-260819` (draft) — touches `src/dragAndDrop.ts`, `src/test/unit/dragAndDropSymlinkFileType.test.ts`
- #123 `docs/testing-guide-260819` — touches `docs/TESTING.md`, `docs/TESTING.zh-TW.md`
- #122 `routine/vt-fix-stale-groupidx-bookmark-cmds-260818` (draft) — touches `src/commands.ts`
- #121 `routine/vt-fix-getscopelabel-basename-260817` (draft) — touches `src/provider.ts`, `src/test/unit/getScopeLabel.test.ts`
- #120 `routine/vt-fix-autogroupbyext-noext-260816` (draft) — touches `src/provider.ts`, `src/test/unit/autoGroupProviderRegression.test.ts`

This PR only touches `src/core/FileManager.ts` and `src/test/unit/fileManagerRelpath.test.ts`, neither of which appears in any of the above diffs, so there is no overlap with in-flight work.

## 2. Changes

`src/core/FileManager.ts` is the shared core module used by the MCP server's file-removal tool (`removeFilesFromGroup`). It only spliced the removed file out of `group.files`, but never cleaned up that file's entry in `group.bookmarks`. The VS Code UI removal path (`provider.ts`, via `GroupFileRemoval.removeStoredFileEntriesFromGroup`) already does this cleanup — this MCP-driven path was the one gap, so a file removed by an AI/MCP tool call would leave its bookmarks stranded in the config file forever (nothing else ever removes them).

The fix mirrors the existing `GroupFileRemoval` logic: after a file is spliced out of `group.files`, any bookmark key matching that file (via the existing `matchesStoredFileEntry` helper, which already tolerates URI/relative-path differences) is deleted, and the `bookmarks` field itself is removed once empty.

Confirms this PR does **not**:
- add/rename/remove any VS Code command registration
- add/rename/remove any contributed configuration key in `package.json`
- add/remove/update any dependency
- change the tab-group serialization format or config storage/migration logic (it only prunes now-orphaned bookmark entries using the same matching rules already used elsewhere)

## 3. Safety Verification

Commands run locally, all passed:
- `npx tsc -p ./` — no errors
- `npm run test -- --testPathPatterns="fileManagerRelpath|removeFilesFromGroup"` — 2 suites, 11 tests passed
- `npm run test` (full suite, includes `tsc -p ./ && jest --runInBand`) — 35 suites, 227 tests passed

No `lint` or `format:check` script exists in `package.json`, so those steps were skipped per the routine checklist.

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump and `CHANGELOG.md` updates are intentionally deferred to the weekend release/integration PR. If CI fails only due to the repository's version-bump release gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.