### PR TITLE
[Routine - VT] fix(core): reject non-finite/non-integer line numbers in BookmarkManager.createBookmark

### DIFF
--- a/mcp-server/src/tools/bookmarkTools.ts
+++ b/mcp-server/src/tools/bookmarkTools.ts
@@ -48,7 +48,7 @@ export class BookmarkTools {
       if (errMsg.includes('does not exist')) {
         return Logger.createError(ErrorType.NOT_FOUND, errMsg);
       }
-      if (errMsg.includes('not in group') || errMsg.includes('must not be negative') || errMsg.includes('must not be empty')) {
+      if (errMsg.includes('not in group') || errMsg.includes('must be a non-negative integer') || errMsg.includes('must not be empty')) {
         return Logger.createError(ErrorType.VALIDATION_ERROR, errMsg);
       }
       return Logger.createError(ErrorType.INTERNAL_ERROR, `Failed to create bookmark: ${errMsg}`);

--- a/src/core/BookmarkManager.ts
+++ b/src/core/BookmarkManager.ts
@@ -176,8 +176,8 @@ export class BookmarkManager {
     }
 
     const group = groups[groupIndex];
-    if (line < 0) {
-      throw new Error('Line number must not be negative');
+    if (!Number.isInteger(line) || line < 0) {
+      throw new Error('Line number must be a non-negative integer');
     }
     if (!label || label.trim() === '') {
       throw new Error('Bookmark label must not be empty');

--- a/src/test/unit/bookmarkManager.test.ts
+++ b/src/test/unit/bookmarkManager.test.ts
@@ -128,4 +128,19 @@ describe('BookmarkManager.createBookmark file membership', () => {
             bm.createBookmark('group-1', path.join(tmpDir, 'src', 'bar.ts'), 0, 'label')
         ).toThrow('File is not in group');
     });
+
+    test.each([NaN, Infinity, -Infinity, 1.5])(
+        'createBookmark rejects a non-integer line number (%p)',
+        (line) => {
+            const { bm } = setupWorkspace([{
+                id: 'group-1',
+                name: 'Test Group',
+                files: ['src/foo.ts']
+            }]);
+
+            expect(() =>
+                bm.createBookmark('group-1', path.join(tmpDir, 'src', 'foo.ts'), line, 'label')
+            ).toThrow('Line number must be a non-negative integer');
+        }
+    );
 });


### PR DESCRIPTION
## Pre-flight Check

Open PRs and active branches checked (Phase 1), with touched files:

- #126 `routine/vt-fix-filemanager-orphaned-bookmarks-260820` — `src/core/FileManager.ts`, `src/test/unit/fileManagerRelpath.test.ts`
- #125 `fix/builtin-group-autosync` — `src/extension.ts`, `src/provider.ts`
- #124 `routine/vt-fix-dragdrop-symlink-filetype-260819` — `src/dragAndDrop.ts`, `src/test/unit/dragAndDropSymlinkFileType.test.ts`
- #123 `docs/testing-guide-260819` — `docs/TESTING.md`, `docs/TESTING.zh-TW.md`
- #122 `routine/vt-fix-stale-groupidx-bookmark-cmds-260818` — `src/commands.ts`
- #121 `routine/vt-fix-getscopelabel-basename-260817` — `src/provider.ts`, `src/test/unit/getScopeLabel.test.ts`
- #120 `routine/vt-fix-autogroupbyext-noext-260816` — `src/provider.ts`, `src/test/unit/autoGroupProviderRegression.test.ts`

This PR touches `src/core/BookmarkManager.ts`, `src/test/unit/bookmarkManager.test.ts`, and `mcp-server/src/tools/bookmarkTools.ts` — none of which overlap with any file listed above. #122 does touch bookmark-related *command handlers* in `src/commands.ts`, but that's a different call path (`BookmarkManager.createBookmarkObject`, the in-memory static constructor fed by a VS Code editor `Position`, which is always a valid non-negative integer) from the one fixed here (the MCP-facing instance method `BookmarkManager.createBookmark`, fed by untyped JSON-RPC args). No functional overlap.

## Changes

`mcp-server`'s `create_bookmark` tool only validated `typeof line === 'number'`, which is true for `NaN`, `Infinity`, `-Infinity`, and fractional values (e.g. `1.5`). Those values then passed straight through `BookmarkManager.createBookmark`'s `line < 0` guard, because comparisons against `NaN`/`Infinity` never satisfy `< 0`. The result: a bookmark could be persisted with a non-integer `line`, which corrupts `getBookmarksForFile`'s numeric sort (`a.line - b.line` on `NaN` is `NaN`, so `Array.sort` treats the ordering as unstable/undefined) and renders as `NaN`/`Infinity` in the UI's `line ${bookmark.line + 1}` labels (tooltip, tree item description, jump-to-bookmark).

Fix: `createBookmark` now requires `Number.isInteger(line) && line >= 0`, rejecting `NaN`, `±Infinity`, and fractional line numbers with a clear validation error. Updated the matching error-message substring check in `mcp-server/src/tools/bookmarkTools.ts` so the MCP tool still surfaces this as a `VALIDATION_ERROR` (not `INTERNAL_ERROR`). Added `test.each` coverage in `src/test/unit/bookmarkManager.test.ts` for `NaN`, `Infinity`, `-Infinity`, and `1.5`.

Confirms this PR does NOT:
- add/rename/remove any VS Code command registration
- add/rename/remove any contributed configuration key in `package.json`
- add/remove/update any dependency
- change the tab-group serialization format or configuration storage/migration logic

## Safety Verification

Commands run locally, all passed:

```
npx tsc -p ./
npm run test        # tsc -p ./ && jest --runInBand → 35 suites, 229 tests passed
cd mcp-server && npx tsc --noEmit
```

No `lint` or `format:check` script exists in `package.json`, so those steps were skipped.

## CI / Release Gate Note

This is a daily routine Draft PR. Package version bump (`package.json`/`package-lock.json`) and `CHANGELOG.md` updates are intentionally deferred to the weekend release/integration PR. If CI fails solely due to the repository's version-bump gate, that is expected release-readiness behavior for a routine PR, not a code validation failure.