### PR TITLE
[Routine - VT] fix(mcp): raise a clear error when the packaged SKILL.md template is missing

### DIFF
--- a/src/mcp/SkillGenerator.ts
+++ b/src/mcp/SkillGenerator.ts
@@ -217,6 +217,9 @@ export class SkillGenerator {
 
     private static buildSkillBody(context: vscode.ExtensionContext, scriptRunPath: string): string {
         const templatePath = path.join(context.extensionPath, 'dist', 'skills', 'virtualtabs', 'SKILL.md');
+        if (!fs.existsSync(templatePath)) {
+            throw new Error(`SKILL.md template not found at ${templatePath}. Run 'npm run build:skills' first.`);
+        }
         const raw = fs.readFileSync(templatePath, 'utf-8');
         const body = raw.replace(/^---\n[\s\S]*?\n---\n\n?/, '');
         return body.replace(/\$\{scriptRunPath\}/g, scriptRunPath);

--- a/src/test/unit/skillGeneratorBuildSkillBody.test.ts
+++ b/src/test/unit/skillGeneratorBuildSkillBody.test.ts
@@ -1,0 +1,45 @@
+jest.mock('vscode', () => ({}), { virtual: true });
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { SkillGenerator } from '../../mcp/SkillGenerator';
+
+type BuildSkillBody = (context: { extensionPath: string }, scriptRunPath: string) => string;
+const buildSkillBody = (SkillGenerator as unknown as { buildSkillBody: BuildSkillBody }).buildSkillBody;
+
+function makeExtensionDir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'vt-skillgen-test-'));
+}
+
+describe('SkillGenerator.buildSkillBody', () => {
+    test('throws a clear, actionable error when the packaged SKILL.md template is missing', () => {
+        const extensionPath = makeExtensionDir();
+        try {
+            expect(() => buildSkillBody({ extensionPath }, 'scripts/vt.bundle.js'))
+                .toThrow(/SKILL\.md template not found.*npm run build:skills/);
+        } finally {
+            fs.rmSync(extensionPath, { recursive: true, force: true });
+        }
+    });
+
+    test('strips the frontmatter and substitutes scriptRunPath when the template exists', () => {
+        const extensionPath = makeExtensionDir();
+        try {
+            const templateDir = path.join(extensionPath, 'dist', 'skills', 'virtualtabs');
+            fs.mkdirSync(templateDir, { recursive: true });
+            fs.writeFileSync(
+                path.join(templateDir, 'SKILL.md'),
+                '---\nname: virtualtabs\n---\n\nRun ${scriptRunPath} to use the tool.',
+                'utf-8'
+            );
+
+            const body = buildSkillBody({ extensionPath }, '.claude/skills/virtualtabs/scripts/vt.bundle.js');
+
+            expect(body).not.toContain('---');
+            expect(body).toBe('Run .claude/skills/virtualtabs/scripts/vt.bundle.js to use the tool.');
+        } finally {
+            fs.rmSync(extensionPath, { recursive: true, force: true });
+        }
+    });
+});


### PR DESCRIPTION
## 1. Pre-flight Check

Open PRs checked (via \`gh pr list --state open\` and \`gh pr diff <n> --name-only\`):

| PR | Files touched |
|----|----|
| #127 | mcp-server/src/tools/bookmarkTools.ts, src/core/BookmarkManager.ts, src/test/unit/bookmarkManager.test.ts |
| #126 | src/core/FileManager.ts, src/test/unit/fileManagerRelpath.test.ts |
| #125 | src/extension.ts, src/provider.ts |
| #124 | src/dragAndDrop.ts, src/test/unit/dragAndDropSymlinkFileType.test.ts |
| #123 | docs/TESTING.md, docs/TESTING.zh-TW.md |
| #122 | src/commands.ts |
| #121 | src/provider.ts, src/test/unit/getScopeLabel.test.ts |
| #120 | src/provider.ts, src/test/unit/autoGroupProviderRegression.test.ts |

Active `routine/*` remote branches at the time of this run were also reviewed and correspond to the PRs above.

This PR touches only `src/mcp/SkillGenerator.ts` and adds a new test file `src/test/unit/skillGeneratorBuildSkillBody.test.ts` — neither overlaps with any file listed above.

## 2. Changes

`SkillGenerator.buildSkillBody` read the packaged `dist/skills/virtualtabs/SKILL.md` template directly via `fs.readFileSync`. If that file is ever missing from the packaged extension (e.g. a packaging/build gap), it throws a raw `ENOENT` instead of an actionable message. The sibling method in the same file, `getVtBundleContent`, already guards its own packaged asset (`dist/vt.bundle.js`) with an `fs.existsSync` check and a clear error pointing at the right build command. This PR applies the same pattern to `buildSkillBody`, pointing users at `npm run build:skills`.

This PR does **not** modify any VS Code command registrations, any contributed configuration keys in `package.json`, any dependencies, or the tab-group serialization/config storage format. It is a pure defensive-error-message change in one helper method.

## 3. Safety Verification

Commands run locally, in order:

```bash
npx tsc -p ./
npm run test:coverage
```

Both passed:
- `npx tsc -p ./` — no type errors.
- `npm run test:coverage` — 36 test suites / 227 tests passed, coverage thresholds met.

Additionally verified the new test is a real regression guard (not a false-positive): stashing just the `SkillGenerator.ts` fix and re-running the new test file shows it fails against the pre-fix code with the raw `ENOENT` message, and passes once the fix is restored.

## 4. CI / Release Gate Note

This is a daily routine Draft PR. Package version bump (`package.json`/`package-lock.json`) and `CHANGELOG.md` updates are intentionally deferred to the weekend release/integration PR. If the "Validate version bump" CI gate flags this PR for lacking a version bump, that is expected release-readiness behavior for a routine PR, not a code validation failure.