### PR TITLE
fix(provider): avoid config writes during built-in tab sync

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -174,7 +174,7 @@ export async function activate(context: vscode.ExtensionContext) {
     // Listen for active editor change to auto-reveal file in the Virtual Tabs panel.
     // NOTE: We intentionally do NOT call syncBuiltInGroup() here to avoid triggering
     // a tree data change event (which clears the registry) mid-reveal, causing a race condition.
-    // Tab open/close events are handled by onDidChangeVisibleTextEditors below.
+    // Tab open/close events are handled by tabGroups.onDidChangeTabs below.
     let lastSelectionUri: string | undefined;
     let lastSelectionTime: number = 0;
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -837,7 +837,9 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
                 }
 
                 this.builtInItemsCache = null;
-                this.saveGroups();
+                // Built-in tab state is derived from VS Code and intentionally excluded
+                // from virtualTab.json. Persisting here only rewrites config files on
+                // every tab event without saving any built-in data.
                 // A scoped fire(builtInItem) was tried here but proved unreliable: when the
                 // built-in group is already expanded, VS Code does not consistently re-query
                 // getChildren() for it on a targeted fire, leaving the visible file list stale

--- a/src/test/unit/builtInGroupSyncPersistence.test.ts
+++ b/src/test/unit/builtInGroupSyncPersistence.test.ts
@@ -1,0 +1,129 @@
+import * as path from 'path';
+import { pathToFileURL } from 'url';
+import type { TempGroup } from '../../types';
+
+jest.mock('vscode', () => {
+    class Uri {
+        private constructor(public readonly fsPath: string) { }
+
+        static file(fsPath: string): Uri {
+            return new Uri(path.resolve(fsPath));
+        }
+
+        static parse(value: string): Uri {
+            if (value.startsWith('file://')) {
+                return new Uri(new URL(value).pathname);
+            }
+            return new Uri(value);
+        }
+
+        static joinPath(base: Uri, ...segments: string[]): Uri {
+            return new Uri(path.join(base.fsPath, ...segments));
+        }
+
+        toString(): string {
+            return pathToFileURL(this.fsPath).toString();
+        }
+    }
+
+    return {
+        Uri,
+        TreeItem: class {
+            constructor(public readonly label: unknown, public readonly collapsibleState?: number) { }
+        },
+        TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+        EventEmitter: class {
+            event = jest.fn();
+            fire = jest.fn();
+        },
+        ThemeIcon: Object.assign(
+            class { constructor(public readonly id: string, public readonly color?: unknown) { } },
+            { File: { id: 'file' } }
+        ),
+        ThemeColor: class { constructor(public readonly id: string) { } },
+        TabInputText: class { },
+        TabInputNotebook: class { },
+        TabInputCustom: class { },
+        TabInputTextDiff: class { },
+        commands: { executeCommand: jest.fn() },
+        window: {
+            tabGroups: { all: [] },
+            showErrorMessage: jest.fn(),
+            showInformationMessage: jest.fn()
+        },
+        workspace: { workspaceFolders: [] }
+    };
+}, { virtual: true });
+
+import { TempFoldersProvider } from '../../provider';
+
+interface ProviderInternals {
+    builtInEditorGroups: Array<{ viewColumn: number; label: string; files: string[] }>;
+    builtInItemsCache: unknown;
+    computeEditorGroups: jest.Mock;
+    saveGroups: jest.Mock;
+    _onDidChangeTreeData: { fire: jest.Mock };
+}
+
+function createProviderHarness(groups: TempGroup[]) {
+    const provider = Object.create(TempFoldersProvider.prototype) as TempFoldersProvider;
+    provider.groups = groups;
+
+    const internals = provider as unknown as ProviderInternals;
+    internals.builtInEditorGroups = [];
+    internals.builtInItemsCache = [];
+    internals.computeEditorGroups = jest.fn();
+    internals.saveGroups = jest.fn();
+    internals._onDidChangeTreeData = { fire: jest.fn() };
+
+    return { provider, internals };
+}
+
+describe('TempFoldersProvider built-in group persistence', () => {
+    test('syncBuiltInGroup updates derived tab state without scheduling a config save', () => {
+        const fileA = 'file:///workspace/a.ts';
+        const fileB = 'file:///workspace/b.ts';
+        const builtIn: TempGroup = {
+            id: 'builtin_group_id',
+            name: 'Currently Open Files',
+            files: [fileA],
+            builtIn: true
+        };
+        const { provider, internals } = createProviderHarness([builtIn]);
+
+        internals.builtInEditorGroups = [
+            { viewColumn: 1, label: 'Editor Group 1', files: [fileA] }
+        ];
+        internals.computeEditorGroups.mockReturnValue([
+            { viewColumn: 1, label: 'Editor Group 1', files: [fileA, fileB] }
+        ]);
+
+        expect(provider.syncBuiltInGroup()).toBe(true);
+        expect(builtIn.files).toEqual([fileA, fileB]);
+        expect(internals.builtInItemsCache).toBeNull();
+        expect(internals._onDidChangeTreeData.fire).toHaveBeenCalledWith(undefined);
+        expect(internals.saveGroups).not.toHaveBeenCalled();
+    });
+
+    test('custom group edits still use the normal persistence path', () => {
+        const builtIn: TempGroup = {
+            id: 'builtin_group_id',
+            name: 'Currently Open Files',
+            files: [],
+            builtIn: true
+        };
+        const custom: TempGroup = {
+            id: 'custom-group',
+            name: 'Custom',
+            files: []
+        };
+        const { provider, internals } = createProviderHarness([builtIn, custom]);
+        internals.computeEditorGroups.mockReturnValue([]);
+
+        provider.addFilesToGroup(1, ['file:///workspace/custom.ts']);
+
+        expect(custom.files).toEqual(['file:///workspace/custom.ts']);
+        expect(internals.saveGroups).toHaveBeenCalledTimes(1);
+        expect(internals._onDidChangeTreeData.fire).toHaveBeenCalledWith(undefined);
+    });
+});


### PR DESCRIPTION
## 背景

`tabGroups.onDidChangeTabs` 會呼叫 `syncBuiltInGroup()`，而該方法原本會排程 `saveGroups()`。但內建「Currently Open Files」群組是由 VS Code tab state 衍生，序列化時本來就會排除，因此每次開啟、關閉、移動或 pin tab 都可能無意義地重寫 `virtualTab.json`。

這條路徑最早源自 #2 / #3，後續由 commit `34802e6` 形成目前的 `syncBuiltInGroup()` 實作；#106 只是讓既有儲存失敗顯示給使用者。#125 改用完整的 tab event 後，更需要在發版前移除這個 built-in-only persistence。

## 變更

- 從 `syncBuiltInGroup()` 移除 `saveGroups()`。
- 保留 `fire(undefined)`，確保展開中的內建群組仍可靠更新。
- 加註 built-in tab state 不應寫入 `virtualTab.json` 的 invariant。
- 更新 `extension.ts` 中已過時的事件名稱註解。
- 新增 regression tests：
  - built-in sync 會更新狀態與 tree，但不排程儲存。
  - 自訂群組編輯仍會走正常 persistence path。

## 驗證

- `npx jest --runInBand src/test/unit/builtInGroupSyncPersistence.test.ts` — 1 suite / 2 tests passed
- `npm test` — TypeScript compile passed；36 suites / 227 tests passed
- `npm run test:coverage` — 36 suites / 227 tests passed；coverage gate passed
- `git diff --check` — passed

## 發版界線

建議將本 PR 視為 `0.11.1` pre-release 的發版閘門。本修正消除 tab change 造成的不必要寫入；若自訂群組等合法儲存操作仍可重現 `EBADF`，應另行追蹤底層 persistence 問題，而不是在此 PR 加入廣泛 retry 或 atomic-write 重構。