### PR TITLE
chore: release v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the "VirtualTabs" extension will be documented in this file.
 
+## [0.11.1] - Currently Open Files Auto-Sync Fix (pre-release) - 2026-08-26
+
+- **fix(provider):** reliably synchronize background and preview tabs in the built-in `Currently Open Files` group without requiring a view switch or manual refresh (#125, contributed by @jianfulin)
+- **fix(provider):** avoid rewriting `virtualTab.json` when only the in-memory built-in tab snapshot changes, eliminating unnecessary config writes from tab-only events (#130)
+
 ## [0.11.0] - Routine Bug-Hunt Batch (pre-release) - 2026-08-16
 
 - **fix(mcp):** guard `validate_json_structure` against non-object array elements — a `null`/primitive entry in an otherwise well-formed array crashed with a misleading "JSON parse error" instead of a clear validation message (#104)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "virtual-tabs",
-    "version": "0.11.0",
+    "version": "0.11.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "virtual-tabs",
-            "version": "0.11.0",
+            "version": "0.11.1",
             "license": "MIT",
             "dependencies": {
                 "fast-glob": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "virtual-tabs",
     "displayName": "VirtualTabs - Virtual File Directories & AI context management",
     "description": "%extension.description%",
-    "version": "0.11.0",
+    "version": "0.11.1",
     "publisher": "winterdrive",
     "icon": "docs/assets/virtualtabs_icon_128.png",
     "categories": [


### PR DESCRIPTION
## 發版目標

發布 VirtualTabs `0.11.1` pre-release，讓 #125 的貢獻者與 pre-release 使用者驗證 `Currently Open Files` 的 background／preview tab 即時同步，以及 #130 對 built-in-only config write 的修正。

## 變更範圍

本 PR 僅包含 release metadata：

- `package.json`: `0.11.0` → `0.11.1`
- `package-lock.json`: 同步 root 與 package version
- `CHANGELOG.md`: 新增 `0.11.1` pre-release notes，標註 #125、#130 與 @jianfulin

沒有 source-code delta，也沒有納入其他 routine draft PR。

## 發版行為

`publish.yml` 只在 `main` 的 `package.json` 變更後觸發。minor `11` 為奇數，因此 workflow 會自動使用 `--pre-release` 發布至 Visual Studio Marketplace 與 Open VSX。

## 驗證

- `npm ci` — succeeded
- `npm test` — TypeScript compile passed；36 suites / 227 tests passed
- `npm run test:coverage` — 36 suites / 227 tests passed；coverage gate passed
- `npm run vscode:prepublish` — succeeded
- local VSIX packaging with `--pre-release` — succeeded（63 files，5.07 MB）
- VSIX manifest — `Version="0.11.1"`，`Microsoft.VisualStudio.Code.PreRelease=true`
- `git diff --check` — passed
- changed files — exactly `CHANGELOG.md`, `package.json`, `package-lock.json`

## 合併後檢查

- 確認 Publish Extension workflow 自動啟動
- 確認 Marketplace 與 Open VSX 均出現 `0.11.1` pre-release
- 請 @jianfulin 與維護者執行 open／preview／close tab smoke test
- 僅操作 tabs 時，確認 `virtualTab.json` 內容與 mtime 不變
- 觀察 24–72 小時後再決定是否 promote 為 `0.12.0` stable