### PR TITLE
fix(provider): avoid cold-start no-op config writes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -147,7 +147,7 @@ export async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(
         treeView.onDidChangeVisibility(e => {
             if (e.visible) {
-                provider.refresh();
+                provider.refreshView();
             }
         })
     );

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -51,6 +51,8 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
 
     // Debounce timer for saving groups to reduce disk I/O
     private saveDebounceTimer: ReturnType<typeof setTimeout> | undefined;
+    private pendingSaveScopeIds: Set<string> = new Set();
+    private pendingSaveAllScopes: boolean = false;
 
     // Flag to ignore file system events triggered by the extension itself
     private isInternalSaving: boolean = false;
@@ -358,13 +360,37 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
         return this.treeView ? [...this.treeView.selection] : [];
     }
 
-    private saveGroups() {
-        // Debounce: Clear any pending save and schedule a new one
+    private takePendingSaveScopeIds(): ReadonlySet<string> | undefined {
+        this.pendingSaveScopeIds ??= new Set();
+        this.pendingSaveAllScopes ??= false;
+        const scopeIds = this.pendingSaveAllScopes
+            ? undefined
+            : new Set(this.pendingSaveScopeIds);
+        this.pendingSaveScopeIds.clear();
+        this.pendingSaveAllScopes = false;
+        return scopeIds;
+    }
+
+    private saveGroups(scopeId?: string) {
+        this.pendingSaveScopeIds ??= new Set();
+        this.pendingSaveAllScopes ??= false;
+
+        // A save without a scope means every configured scope may have changed.
+        // Scoped saves are accumulated so rapid edits in different scopes are not lost.
+        if (scopeId && !this.pendingSaveAllScopes) {
+            this.pendingSaveScopeIds.add(scopeId);
+        } else if (!scopeId) {
+            this.pendingSaveAllScopes = true;
+            this.pendingSaveScopeIds.clear();
+        }
+
+        // Debounce: Clear any pending save and schedule a new one.
         if (this.saveDebounceTimer) {
             clearTimeout(this.saveDebounceTimer);
         }
         this.saveDebounceTimer = setTimeout(() => {
-            this.saveGroupsImmediate();
+            this.saveDebounceTimer = undefined;
+            this.saveGroupsImmediate(this.takePendingSaveScopeIds());
         }, 500);
     }
 
@@ -378,11 +404,11 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
         if (this.saveDebounceTimer) {
             clearTimeout(this.saveDebounceTimer);
             this.saveDebounceTimer = undefined;
-            this.saveGroupsImmediate();
+            this.saveGroupsImmediate(this.takePendingSaveScopeIds());
         }
     }
 
-    private saveGroupsImmediate() {
+    private saveGroupsImmediate(scopeIds?: ReadonlySet<string>) {
         if (this.groupManagers.size === 0) {
             console.warn('Cannot save VirtualTabs data: no GroupManagers available');
             return;
@@ -392,7 +418,9 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
             // 依 sourceScopeId 路由至對應的 GroupManager
             // 先將群組依 scopeId 分組
             const groupsByScopeId = new Map<string, TempGroup[]>(
-                this.configScopes.map(scope => [scope.id, []])
+                this.configScopes
+                    .filter(scope => !scopeIds || scopeIds.has(scope.id))
+                    .map(scope => [scope.id, []])
             );
 
             for (const group of this.groups) {
@@ -406,7 +434,7 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
                 if (!scopeId) {
                     // 無 sourceScopeId：使用第一個可用的 scope（向下相容）
                     const firstScopeId = this.configScopes[0]?.id;
-                    if (firstScopeId) {
+                    if (firstScopeId && (!scopeIds || scopeIds.has(firstScopeId))) {
                         if (!groupsByScopeId.has(firstScopeId)) {
                             groupsByScopeId.set(firstScopeId, []);
                         }
@@ -414,6 +442,8 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
                     }
                     continue;
                 }
+
+                if (scopeIds && !scopeIds.has(scopeId)) continue;
 
                 if (!this.groupManagers.has(scopeId)) {
                     console.warn(`VirtualTabs: sourceScopeId "${scopeId}" does not match any known ConfigScope, skipping save for group "${group.name}"`);
@@ -880,6 +910,11 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
         this._onDidChangeTreeData.fire(undefined);
     }
 
+    /** Refresh the visible tree without rewriting persisted custom groups. */
+    refreshView(): void {
+        this.refresh(false);
+    }
+
     addGroup() {
         const nonBuiltinActive = [...this.activeScopeIds].filter(id => id !== BUILTIN_SCOPE_ID);
         if (nonBuiltinActive.length === 1) {
@@ -943,8 +978,9 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
         this.expandedScopeIds.add(scopeId);
 
         if (save) {
+            // Let VS Code paint the new group before the debounced persistence work runs.
             this.refresh(false);
-            this.saveGroupsImmediate();
+            this.saveGroups(scopeId);
         }
 
         return this.groups.length - 1;

--- a/src/test/ui/selfRoot/scopeCollision.selfroot.ts
+++ b/src/test/ui/selfRoot/scopeCollision.selfroot.ts
@@ -5,8 +5,8 @@
  * `vscode` module), this launches the packaged extension inside a real VS
  * Code instance opened directly against a self-root .code-workspace
  * (`"folders": [{ "path": "." }]`), and drives the exact user-facing actions
- * that triggered the reported bug: toggling the Virtual Tabs view (fires
- * `refresh(true)`, which persists) and clicking Refresh (calls
+ * that triggered the reported bug: toggling the Virtual Tabs view (fires a
+ * UI-only refresh) and clicking Refresh (calls
  * `reinitializeScopes()`, which re-discovers scopes). Confirms the persisted
  * `.vscode/virtualTab.json` group count never grows across repeated cycles,
  * and that the tree never renders a duplicated scope section.
@@ -160,12 +160,18 @@ describe('Self-root .code-workspace — no group doubling across reopen cycles (
         await waitForTreeLabel('Self-Root Existing');
 
         for (let cycle = 1; cycle <= 3; cycle++) {
+            const mtimeBeforeVisibilityToggle = fs.statSync(configPath).mtimeMs;
+
             // Half of the real reopen sequence: hide the view, then show it
             // again — this fires the treeView.onDidChangeVisibility(true)
-            // listener, which calls provider.refresh(true) and persists
-            // whatever is currently in memory.
+            // listener, which refreshes the UI without rewriting config.
             await closeVirtualTabsView();
             sidebar = await openVirtualTabsView();
+            await VSBrowser.instance.driver.sleep(800);
+            expect(
+                fs.statSync(configPath).mtimeMs,
+                `config mtime after visibility toggle ${cycle}`
+            ).to.equal(mtimeBeforeVisibilityToggle);
 
             // The other half: the Refresh button calls
             // provider.reinitializeScopes(), re-running ConfigScopeDiscovery

--- a/src/test/unit/builtInGroupSyncPersistence.test.ts
+++ b/src/test/unit/builtInGroupSyncPersistence.test.ts
@@ -1,3 +1,5 @@
+import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { pathToFileURL } from 'url';
 import type { TempGroup } from '../../types';
@@ -56,12 +58,20 @@ jest.mock('vscode', () => {
 }, { virtual: true });
 
 import { TempFoldersProvider } from '../../provider';
+import { GroupManager } from '../../core/GroupManager';
 
 interface ProviderInternals {
     builtInEditorGroups: Array<{ viewColumn: number; label: string; files: string[] }>;
     builtInItemsCache: unknown;
     computeEditorGroups: jest.Mock;
     saveGroups: jest.Mock;
+    saveGroupsImmediate: jest.Mock;
+    pendingSaveScopeIds: Set<string>;
+    pendingSaveAllScopes: boolean;
+    groupManagers: Map<string, unknown>;
+    loadedVersions: Map<string, number>;
+    expandedScopeIds: Set<string>;
+    isInternalSaving: boolean;
     _onDidChangeTreeData: { fire: jest.Mock };
 }
 
@@ -74,6 +84,13 @@ function createProviderHarness(groups: TempGroup[]) {
     internals.builtInItemsCache = [];
     internals.computeEditorGroups = jest.fn();
     internals.saveGroups = jest.fn();
+    internals.saveGroupsImmediate = jest.fn();
+    internals.pendingSaveScopeIds = new Set();
+    internals.pendingSaveAllScopes = false;
+    internals.groupManagers = new Map();
+    internals.loadedVersions = new Map();
+    internals.expandedScopeIds = new Set();
+    internals.isInternalSaving = false;
     internals._onDidChangeTreeData = { fire: jest.fn() };
 
     return { provider, internals };
@@ -125,5 +142,126 @@ describe('TempFoldersProvider built-in group persistence', () => {
         expect(custom.files).toEqual(['file:///workspace/custom.ts']);
         expect(internals.saveGroups).toHaveBeenCalledTimes(1);
         expect(internals._onDidChangeTreeData.fire).toHaveBeenCalledWith(undefined);
+    });
+
+    test('showing the view refreshes derived state without scheduling a config save', () => {
+        const builtIn: TempGroup = {
+            id: 'builtin_group_id',
+            name: 'Currently Open Files',
+            files: [],
+            builtIn: true
+        };
+        const { provider, internals } = createProviderHarness([builtIn]);
+        internals.computeEditorGroups.mockReturnValue([]);
+
+        provider.refreshView();
+
+        expect(internals.saveGroups).not.toHaveBeenCalled();
+        expect(internals._onDidChangeTreeData.fire).toHaveBeenCalledWith(undefined);
+    });
+
+    test('creating a scoped group paints first and schedules only that scope', () => {
+        const { provider, internals } = createProviderHarness([]);
+        internals.groupManagers.set('scope-a', {});
+        const refresh = jest.spyOn(provider, 'refresh').mockImplementation(() => undefined);
+
+        const groupIndex = provider.createGroupInScope('scope-a');
+
+        expect(groupIndex).toBe(0);
+        expect(provider.groups[0].sourceScopeId).toBe('scope-a');
+        expect(refresh).toHaveBeenCalledWith(false);
+        expect(internals.saveGroups).toHaveBeenCalledWith('scope-a');
+        expect(internals.expandedScopeIds.has('scope-a')).toBe(true);
+    });
+
+    test('debounce unions scoped saves and clears the timer after it runs', () => {
+        jest.useFakeTimers();
+        try {
+            const { provider, internals } = createProviderHarness([]);
+            const saveGroups = (TempFoldersProvider.prototype as unknown as {
+                saveGroups: (scopeId?: string) => void;
+            }).saveGroups.bind(provider);
+
+            saveGroups('scope-a');
+            saveGroups('scope-b');
+            jest.advanceTimersByTime(500);
+
+            expect(internals.saveGroupsImmediate).toHaveBeenCalledTimes(1);
+            const scopeIds = internals.saveGroupsImmediate.mock.calls[0][0] as ReadonlySet<string>;
+            expect([...scopeIds].sort()).toEqual(['scope-a', 'scope-b']);
+
+            provider.flushPendingSave();
+            expect(internals.saveGroupsImmediate).toHaveBeenCalledTimes(1);
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    test('an unscoped save supersedes pending scoped saves', () => {
+        jest.useFakeTimers();
+        try {
+            const { provider, internals } = createProviderHarness([]);
+            const saveGroups = (TempFoldersProvider.prototype as unknown as {
+                saveGroups: (scopeId?: string) => void;
+            }).saveGroups.bind(provider);
+
+            saveGroups('scope-a');
+            saveGroups();
+            jest.advanceTimersByTime(500);
+
+            expect(internals.saveGroupsImmediate).toHaveBeenCalledWith(undefined);
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    test('a scoped save leaves other workspace configs byte-for-byte unchanged', () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'virtualtabs-scoped-save-'));
+        try {
+            const rootA = path.join(root, 'a');
+            const rootB = path.join(root, 'b');
+            fs.mkdirSync(path.join(rootA, '.vscode'), { recursive: true });
+            fs.mkdirSync(path.join(rootB, '.vscode'), { recursive: true });
+
+            const configA = path.join(rootA, '.vscode', 'virtualTab.json');
+            const configB = path.join(rootB, '.vscode', 'virtualTab.json');
+            fs.writeFileSync(configA, JSON.stringify([{ id: 'old-a', name: 'Old A', files: [] }], null, 2));
+            fs.writeFileSync(configB, JSON.stringify([{ id: 'old-b', name: 'Old B', files: [] }], null, 2));
+            const originalB = fs.readFileSync(configB, 'utf8');
+
+            const managerA = new GroupManager(rootA);
+            const managerB = new GroupManager(rootB);
+            const versionA = managerA.loadGroups().version;
+            const versionB = managerB.loadGroups().version;
+
+            const { provider, internals } = createProviderHarness([
+                { id: 'new-a', name: 'New A', files: [], sourceScopeId: 'scope-a' },
+                { id: 'old-b', name: 'Old B', files: [], sourceScopeId: 'scope-b' }
+            ]);
+            provider.configScopes = [
+                { id: 'scope-a', type: 'folder', label: 'A', uri: { fsPath: rootA } } as never,
+                { id: 'scope-b', type: 'folder', label: 'B', uri: { fsPath: rootB } } as never
+            ];
+            internals.groupManagers = new Map([
+                ['scope-a', managerA],
+                ['scope-b', managerB]
+            ]);
+            internals.loadedVersions = new Map([
+                ['scope-a', versionA],
+                ['scope-b', versionB]
+            ]);
+
+            const saveGroupsImmediate = (TempFoldersProvider.prototype as unknown as {
+                saveGroupsImmediate: (scopeIds?: ReadonlySet<string>) => void;
+            }).saveGroupsImmediate.bind(provider);
+            saveGroupsImmediate(new Set(['scope-a']));
+
+            expect(JSON.parse(fs.readFileSync(configA, 'utf8'))).toEqual([
+                { id: 'new-a', name: 'New A', files: [] }
+            ]);
+            expect(fs.readFileSync(configB, 'utf8')).toBe(originalB);
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
     });
 });


### PR DESCRIPTION
## 摘要

- VirtualTabs View 顯示時只更新 UI，不再無條件排程寫入所有 `virtualTab.json`
- 新增 scoped group 時先讓 TreeView 顯示，再以 500ms debounce 排程儲存
- debounce 會合併不同 scope 的修改；新增群組只寫實際變更的 scope
- timer 執行後立即清除 pending 狀態，避免 extension deactivation 重複寫入
- self-root UI regression 同時驗證 View visibility toggle 不改變 config mtime

## 背景

`0.11.1` pre-release 實機驗證發現 cold-start 後第一次顯示 VirtualTabs／新增群組可能延遲 5–10 秒。程式碼與檔案 mtime 顯示 View visibility 會呼叫預設 `save=true` 的 `refresh()`，而新增群組直接在 command handler 內執行同步的 `saveGroupsImmediate()`。

本 PR 處理 #134 已確認的無效寫入與 command-path 阻塞。Windows `EBADF` 根因仍由 #135 獨立追蹤，本 PR 不宣稱已根治。

## 驗證

- `npm test`：36 suites / 232 tests passed
- `npm run test:coverage`：100% statements/functions/lines；96.15% branches
- `npx tsc -p tsconfig.test.ui.json --noEmit`
- `npm run test:ui:selfroot`（使用全新隔離 VS Code 1.96 runtime）：1 passing
- `git diff --check`

Refs #134
Refs #135