### PR TITLE
chore: release v0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the "VirtualTabs" extension will be documented in this file.
 
+## [0.11.2] - Cold-Start Config I/O Fix (pre-release) - 2026-08-26
+
+- **fix(provider):** refresh the VirtualTabs view without rewriting unchanged `virtualTab.json` files, let newly created groups render before debounced persistence, and limit scoped group creation to saving only the modified workspace scope (#136)
+- **fix(provider):** clear completed save timers and merge pending scoped saves so extension deactivation does not repeat an already-finished write (#136)
+
 ## [0.11.1] - Currently Open Files Auto-Sync Fix (pre-release) - 2026-08-26
 
 - **fix(provider):** reliably synchronize background and preview tabs in the built-in `Currently Open Files` group without requiring a view switch or manual refresh (#125, contributed by @jianfulin)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "virtual-tabs",
-    "version": "0.11.1",
+    "version": "0.11.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "virtual-tabs",
-            "version": "0.11.1",
+            "version": "0.11.2",
             "license": "MIT",
             "dependencies": {
                 "fast-glob": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "virtual-tabs",
     "displayName": "VirtualTabs - Virtual File Directories & AI context management",
     "description": "%extension.description%",
-    "version": "0.11.1",
+    "version": "0.11.2",
     "publisher": "winterdrive",
     "icon": "docs/assets/virtualtabs_icon_128.png",
     "categories": [


### PR DESCRIPTION
## 摘要

發布 `0.11.2` pre-release，承載 #136 的 cold-start／無效設定檔寫入修正。

## 內容

- VirtualTabs View 顯示時不再重寫未變更的 `virtualTab.json`
- 新增群組先更新 TreeView，再 debounce 儲存
- scoped group creation 只寫入被修改的 workspace scope
- completed debounce timer 不會在 extension deactivation 時重複寫入

## 發版範圍

本 PR 僅包含：

- `CHANGELOG.md`
- `package.json`
- `package-lock.json`

Windows `EBADF` 根因仍由 #135 追蹤，本版將用來觀察減少無效／跨 scope 寫入後的實機結果。

## 驗證

- `npm test`：36 suites / 232 tests passed
- `npm run test:coverage`：100% statements/functions/lines；96.15% branches
- real VS Code 1.96 self-root UI test：1 passing
- VSIX：`0.11.2`、`PreRelease=true`、5,321,172 bytes
- `git diff --check`