### PR TITLE
chore: release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the "VirtualTabs" extension will be documented in this file.
 
+## [0.12.0] - Stable Release: Reliable Tab Sync & Faster Cold Start - 2026-08-26
+
+- **Stable Promotion:** promotes the tested `0.11.1` and `0.11.2` pre-release fixes to the stable tier.
+- **fix(provider):** reliably synchronize background, preview, close, move, pin, and split-editor tab changes in the built-in `Currently Open Files` group without requiring a view switch or manual refresh (#125, contributed by @jianfulin).
+- **fix(provider):** keep tab-only synchronization in memory instead of rewriting `virtualTab.json`, reducing unnecessary filesystem work and save-error exposure (#130).
+- **fix(provider):** avoid no-op config writes when the VirtualTabs view first appears, render newly created scoped groups before debounced persistence, save only the modified scope, and avoid a duplicate deactivation write (#136).
+- **Manual verification:** Windows multi-root testing covered cold start, preview replacement, Open to Side, custom-group create/rename/duplicate/delete, persistence across Reload Window, and confirmed no observed `EBADF` during the release smoke test.
+- **Known issue:** in a multi-root workspace, `Duplicate Group (Currently Open Files)` may not appear until Refresh/Reload, after which the snapshot is visible under `Workspace Config` (#138). Avoid repeated clicks until this follow-up is fixed.
+
 ## [0.11.2] - Cold-Start Config I/O Fix (pre-release) - 2026-08-26
 
 - **fix(provider):** refresh the VirtualTabs view without rewriting unchanged `virtualTab.json` files, let newly created groups render before debounced persistence, and limit scoped group creation to saving only the modified workspace scope (#136)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "virtual-tabs",
-    "version": "0.11.2",
+    "version": "0.12.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "virtual-tabs",
-            "version": "0.11.2",
+            "version": "0.12.0",
             "license": "MIT",
             "dependencies": {
                 "fast-glob": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "virtual-tabs",
     "displayName": "VirtualTabs - Virtual File Directories & AI context management",
     "description": "%extension.description%",
-    "version": "0.11.2",
+    "version": "0.12.0",
     "publisher": "winterdrive",
     "icon": "docs/assets/virtualtabs_icon_128.png",
     "categories": [


### PR DESCRIPTION
## 摘要

將已完成 Windows multi-root 實機驗證的 `0.11.1`／`0.11.2` pre-release 內容晉級為 `0.12.0 stable`。

## 正式版內容

- PR #125：可靠同步 background、preview、close、move、pin 與 split-editor tab 事件（由 @jianfulin 貢獻）
- PR #130：tab-only event 不再重寫 `virtualTab.json`
- PR #136：避免 cold-start 無效寫入、scoped group UI-first 顯示、僅保存變更 scope，並避免 deactivation 重複寫入

本 PR 僅修改：

- `CHANGELOG.md`
- `package.json`
- `package-lock.json`

不包含任何新的 runtime code 或其他 open PR。

## 已知問題

- #138：multi-root 下 `Duplicate Group (Currently Open Files)` 可能需 Refresh／Reload 才出現在 `Workspace Config`；有明確 workaround，列為後續追蹤。
- #135：Windows `EBADF` 根因仍追蹤中；本次 `0.11.2` 實機 smoke test 未再復現。

## 驗證

- `npm test`：36 suites / 232 tests passed
- `npm run test:coverage`：100% statements/functions/lines；96.15% branches
- `npx tsc -p ./ --noEmit`
- stable VSIX：`0.12.0`、`PreRelease=false`、5,321,520 bytes
- VSIX SHA-256：`6AFC5EE524E9E5B733FB1DE3FF5ABC6C8630C4BD604F44EAA6A448203EEDA2A8`
- Windows multi-root manual smoke：preview replacement、Open to Side、custom-group create/rename/duplicate/delete、Reload persistence 均通過，未觀察到 `EBADF`
- `git diff --check`