### PR TITLE
fix(commands): show built-in group duplicate immediately in multi-root

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -811,24 +811,7 @@ export function registerCommands(
     // Duplicate built-in group
     context.subscriptions.push(vscode.commands.registerCommand('virtualTabs.duplicateBuiltInGroup', (item: TempFolderItem) => {
         if (typeof item?.groupIdx !== 'number') return;
-        const group = provider.groups[item.groupIdx];
-        if (!group || !group.builtIn) return;
-
-        // Generate new name
-        let base = I18n.getBuiltInGroupName();
-        let idx = 1;
-        let newName = I18n.getCopyGroupName(base);
-        while (provider.groups.some(g => g.name === newName)) {
-            idx++;
-            newName = I18n.getCopyGroupName(base, idx);
-        }
-
-        provider.groups.push({
-            id: Date.now().toString() + Math.random().toString(36).substring(2, 9),
-            name: newName,
-            files: group.files ? [...group.files] : []
-        });
-        provider.refresh();
+        provider.duplicateBuiltInGroup(item.groupIdx);
     }));
 
     // Refresh built-in group

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -989,6 +989,39 @@ export class TempFoldersProvider implements vscode.TreeDataProvider<vscode.TreeI
         return this.groups.length - 1;
     }
 
+    duplicateBuiltInGroup(groupIdx: number): number | undefined {
+        const source = this.groups[groupIdx];
+        if (!source?.builtIn) return undefined;
+
+        // The built-in group is workspace-wide. In a multi-root workspace its
+        // persisted copy belongs to Workspace Config; in a single-folder
+        // window the only folder scope is the persistence target.
+        const targetScope = this.configScopes.find(scope => scope.type === 'workspace')
+            ?? this.configScopes[0];
+        if (!targetScope || !this.groupManagers.has(targetScope.id)) return undefined;
+
+        const base = I18n.getBuiltInGroupName();
+        let copyIndex = 1;
+        let name = I18n.getCopyGroupName(base);
+        while (this.groups.some(group => group.name === name)) {
+            copyIndex++;
+            name = I18n.getCopyGroupName(base, copyIndex);
+        }
+
+        this.groups.push({
+            id: Date.now().toString() + Math.random().toString(36).substring(2, 9),
+            name,
+            files: source.files ? [...source.files] : [],
+            sourceScopeId: targetScope.id
+        });
+        this.expandedScopeIds.add(targetScope.id);
+
+        // Paint the scoped copy immediately, then persist only its target scope.
+        this.refresh(false);
+        this.saveGroups(targetScope.id);
+        return this.groups.length - 1;
+    }
+
     addSubGroup(parentGroupId: string) {
         // Validation: Parent must exist (unless it's null, but view logic handles that)
         const parent = this.groups.find(g => g.id === parentGroupId);

--- a/src/test/unit/builtInGroupSyncPersistence.test.ts
+++ b/src/test/unit/builtInGroupSyncPersistence.test.ts
@@ -174,6 +174,57 @@ describe('TempFoldersProvider built-in group persistence', () => {
         expect(internals.expandedScopeIds.has('scope-a')).toBe(true);
     });
 
+    test('duplicating the built-in group targets Workspace Config and is visible immediately', () => {
+        const sourceFiles = ['file:///workspace/a.ts', 'file:///workspace/b.ts'];
+        const { provider, internals } = createProviderHarness([{
+            id: 'builtin_group_id',
+            name: 'Currently Open Files',
+            files: sourceFiles,
+            builtIn: true
+        }]);
+        provider.configScopes = [
+            { id: 'scope:workspace', type: 'workspace', label: 'Workspace Config', uri: { fsPath: '/workspace' } } as never,
+            { id: 'scope:project', type: 'folder', label: 'Project', uri: { fsPath: '/workspace/project' } } as never
+        ];
+        internals.groupManagers = new Map([
+            ['scope:workspace', {}],
+            ['scope:project', {}]
+        ]);
+        const refresh = jest.spyOn(provider, 'refresh').mockImplementation(() => undefined);
+
+        const groupIndex = provider.duplicateBuiltInGroup(0);
+
+        expect(groupIndex).toBe(1);
+        expect(provider.groups[1]).toMatchObject({
+            files: sourceFiles,
+            sourceScopeId: 'scope:workspace'
+        });
+        expect(provider.groups[1].files).not.toBe(sourceFiles);
+        expect(internals.expandedScopeIds.has('scope:workspace')).toBe(true);
+        expect(refresh).toHaveBeenCalledWith(false);
+        expect(internals.saveGroups).toHaveBeenCalledWith('scope:workspace');
+        expect(refresh.mock.invocationCallOrder[0]).toBeLessThan(internals.saveGroups.mock.invocationCallOrder[0]);
+    });
+
+    test('duplicating the built-in group uses the folder scope in a single-folder window', () => {
+        const { provider, internals } = createProviderHarness([{
+            id: 'builtin_group_id',
+            name: 'Currently Open Files',
+            files: [],
+            builtIn: true
+        }]);
+        provider.configScopes = [
+            { id: 'scope:folder', type: 'folder', label: 'Project', uri: { fsPath: '/project' } } as never
+        ];
+        internals.groupManagers.set('scope:folder', {});
+        jest.spyOn(provider, 'refresh').mockImplementation(() => undefined);
+
+        provider.duplicateBuiltInGroup(0);
+
+        expect(provider.groups[1].sourceScopeId).toBe('scope:folder');
+        expect(internals.saveGroups).toHaveBeenCalledWith('scope:folder');
+    });
+
     test('debounce unions scoped saves and clears the timer after it runs', () => {
         jest.useFakeTimers();
         try {


### PR DESCRIPTION
## 摘要

修正 multi-root workspace 對 Currently Open Files 執行 Duplicate 後，必須手動重新整理才看得到副本的問題。

- workspace-wide built-in group 的副本固定指派到 Workspace Config
- single-folder window 使用唯一 folder scope
- 建立後先 refresh TreeView，再只 debounce 儲存目標 scope
- 保留檔案清單的獨立副本，避免和 built-in group 共用陣列

## 驗證

- npx tsc -p ./
- npm test -- --runInBand src/test/unit/builtInGroupSyncPersistence.test.ts：9 passed
- npm run test:coverage：38 suites / 247 tests passed
- 本機巢狀 worktree 的 VSIX prepublish 受到既有 bundle-vt.ts 路徑限制；GitHub Validate 會在一般 checkout 重新驗證完整打包

Fixes #138