### PR TITLE
fix(provider): sync editor-group topology changes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -241,7 +241,7 @@ export async function activate(context: vscode.ExtensionContext) {
         }
     });
 
-    // Listen for editor file open/close events to auto-refresh the tree view.
+    // Listen for both tab content changes and editor-group topology changes.
     // Only use syncBuiltInGroup here to avoid recreating the entire tree when switching tabs.
     //
     // Uses tabGroups.onDidChangeTabs rather than onDidChangeVisibleTextEditors:
@@ -249,11 +249,16 @@ export async function activate(context: vscode.ExtensionContext) {
     // can miss tabs opened in the background or as a preview tab (single-click
     // in Explorer) that don't change the set of *visible* editors — leaving the
     // built-in "Currently Open Files" group stale until a manual refresh.
-    // tabGroups.onDidChangeTabs fires for open/close/move/pin on every tab.
+    // onDidChangeTabs covers open/close/move/pin on every tab, while
+    // onDidChangeTabGroups covers split creation/removal and group reordering.
+    // The shared callback is snapshot-guarded: a duplicate event with no
+    // effective change does not fire another TreeView refresh.
+    const syncBuiltInGroup = () => {
+        provider.syncBuiltInGroup();
+    };
     context.subscriptions.push(
-        vscode.window.tabGroups.onDidChangeTabs(() => {
-            provider.syncBuiltInGroup();
-        })
+        vscode.window.tabGroups.onDidChangeTabs(syncBuiltInGroup),
+        vscode.window.tabGroups.onDidChangeTabGroups(syncBuiltInGroup)
     );
 
     // Register all commands

--- a/src/test/ui/contextMenuAvailability.ui.test.ts
+++ b/src/test/ui/contextMenuAvailability.ui.test.ts
@@ -745,7 +745,7 @@ describe('Menu Availability Matrix – File (Built-in Group) (virtualTabsFileBui
         // Open the file so it appears under "Currently Open Files"
         await VSBrowser.instance.openResources(testFileAbsPath);
 
-        // Give the extension time to process onDidChangeVisibleTextEditors,
+        // Give the extension time to process tabGroups.onDidChangeTabs,
         // then expand the built-in group so the file is visible in tree rows.
         const driver = VSBrowser.instance.driver;
         await driver.sleep(800);

--- a/src/test/ui/copySubmenu.ui.test.ts
+++ b/src/test/ui/copySubmenu.ui.test.ts
@@ -480,7 +480,7 @@ describe('Copy Submenu – File (Built-in Group)', function () {
         await VSBrowser.instance.openResources(testFileAbsPath);
         await reloadVirtualTabsView();
 
-        // Give the extension time to process onDidChangeVisibleTextEditors,
+        // Give the extension time to process tabGroups.onDidChangeTabs,
         // then expand the built-in group so the file is visible in tree rows.
         const driver = VSBrowser.instance.driver;
         await driver.sleep(800);

--- a/src/test/ui/executableFile.ui.test.ts
+++ b/src/test/ui/executableFile.ui.test.ts
@@ -429,7 +429,7 @@ describe('Menu Availability Matrix – Executable File (Built-in Group) (virtual
         await VSBrowser.instance.openResources(execFileAbsPath);
         await reloadVirtualTabsView();
 
-        // Give the extension time to process onDidChangeVisibleTextEditors,
+        // Give the extension time to process tabGroups.onDidChangeTabs,
         // then expand the built-in group so the file is visible in tree rows.
         const driver = VSBrowser.instance.driver;
         await driver.sleep(800);

--- a/src/test/unit/builtInGroupSyncPersistence.test.ts
+++ b/src/test/unit/builtInGroupSyncPersistence.test.ts
@@ -122,6 +122,49 @@ describe('TempFoldersProvider built-in group persistence', () => {
         expect(internals.saveGroups).not.toHaveBeenCalled();
     });
 
+    test('syncBuiltInGroup refreshes when editor-group topology changes with the same files', () => {
+        const fileA = 'file:///workspace/a.ts';
+        const fileB = 'file:///workspace/b.ts';
+        const builtIn: TempGroup = {
+            id: 'builtin_group_id',
+            name: 'Currently Open Files',
+            files: [fileA, fileB],
+            builtIn: true
+        };
+        const { provider, internals } = createProviderHarness([builtIn]);
+        internals.builtInEditorGroups = [
+            { viewColumn: 1, label: 'Editor Group 1', files: [fileA, fileB] }
+        ];
+        internals.computeEditorGroups.mockReturnValue([
+            { viewColumn: 1, label: 'Editor Group 1', files: [fileA] },
+            { viewColumn: 2, label: 'Editor Group 2', files: [fileB] }
+        ]);
+
+        expect(provider.syncBuiltInGroup()).toBe(true);
+        expect(builtIn.files).toEqual([fileA, fileB]);
+        expect(internals.builtInEditorGroups).toHaveLength(2);
+        expect(internals._onDidChangeTreeData.fire).toHaveBeenCalledWith(undefined);
+        expect(internals.saveGroups).not.toHaveBeenCalled();
+    });
+
+    test('syncBuiltInGroup ignores duplicate events when the snapshot is unchanged', () => {
+        const fileA = 'file:///workspace/a.ts';
+        const builtIn: TempGroup = {
+            id: 'builtin_group_id',
+            name: 'Currently Open Files',
+            files: [fileA],
+            builtIn: true
+        };
+        const { provider, internals } = createProviderHarness([builtIn]);
+        const snapshot = [{ viewColumn: 1, label: 'Editor Group 1', files: [fileA] }];
+        internals.builtInEditorGroups = snapshot;
+        internals.computeEditorGroups.mockReturnValue(snapshot);
+
+        expect(provider.syncBuiltInGroup()).toBe(false);
+        expect(internals._onDidChangeTreeData.fire).not.toHaveBeenCalled();
+        expect(internals.saveGroups).not.toHaveBeenCalled();
+    });
+
     test('custom group edits still use the normal persistence path', () => {
         const builtIn: TempGroup = {
             id: 'builtin_group_id',


### PR DESCRIPTION
## 摘要

補齊 Currently Open Files 對 editor-group topology 變更的同步。

- onDidChangeTabs 與 onDidChangeTabGroups 共用同一個 sync callback
- split 建立或移除、group 重排與跨 group 移動後同步內建群組結構
- 保留 snapshot guard；重複事件在狀態未變時不觸發額外 TreeView refresh
- 更新 UI tests 內已過期的事件註解

## 驗證

- npx tsc -p ./
- targeted regression：11 tests passed
- npm run test:coverage：38 suites / 249 tests passed

Fixes #129