### PR TITLE
chore: release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the "VirtualTabs" extension will be documented in this file.
 
+## [0.13.0] - Multi-Root & State-Consistency Batch (pre-release) - 2026-08-27
+
+- **fix(commands):** duplicate the built-in `Currently Open Files` group into an explicit target scope, show it immediately, and persist only that scope; multi-root workspaces use `Workspace Config`, while single-folder windows use their folder scope (#140, fixes #138).
+- **fix(provider):** synchronize editor-group topology changes such as split creation/removal and group reordering through `tabGroups.onDidChangeTabGroups`, while snapshot guards suppress duplicate TreeView refreshes (#141, fixes #129).
+- **fix(provider):** group extensionless files together under `no-extension` instead of creating a separate Auto Group for each filename (#120).
+- **fix(core):** display VS Code's configured workspace-folder label, including custom multi-root names and filesystem-root folders (#121).
+- **fix(commands):** ignore bookmark edit/remove commands whose captured group index is stale instead of dereferencing a missing group (#122).
+- **fix(core):** remove orphaned bookmarks when MCP-driven file removal drops their file from a group (#126).
+- **fix(core):** reject non-finite and non-integer bookmark line numbers at the shared core boundary (#127).
+- **fix(mcp):** report an actionable error when the packaged `SKILL.md` template is missing (#128).
+- **docs(testing):** refresh the maintained automated-testing reference for the current 38-suite / 249-test baseline (#123).
+- **Known monitoring item:** Windows `EBADF` config-save failures have not reappeared in recent smoke tests, but the underlying synchronous persistence strategy remains tracked in #135 and is not claimed fixed by this release.
+
 ## [0.12.0] - Stable Release: Reliable Tab Sync & Faster Cold Start - 2026-08-26
 
 - **Stable Promotion:** promotes the tested `0.11.1` and `0.11.2` pre-release fixes to the stable tier.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "virtual-tabs",
-    "version": "0.12.0",
+    "version": "0.13.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "virtual-tabs",
-            "version": "0.12.0",
+            "version": "0.13.0",
             "license": "MIT",
             "dependencies": {
                 "fast-glob": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "virtual-tabs",
     "displayName": "VirtualTabs - Virtual File Directories & AI context management",
     "description": "%extension.description%",
-    "version": "0.12.0",
+    "version": "0.13.0",
     "publisher": "winterdrive",
     "icon": "docs/assets/virtualtabs_icon_128.png",
     "categories": [


### PR DESCRIPTION
## Release manifest

0.13.0 是 stable/pre-release 雙軌策略中的批次整合型 pre-release。

### Included runtime PRs

- #120：無副檔名 Auto Group
- #121：正確使用 scope.label
- #122：stale bookmark command guard
- #126：移除 orphan bookmarks
- #127：bookmark line number validation
- #128：缺少 SKILL.md template 的明確錯誤
- #140：multi-root built-in Duplicate 立即顯示並正確儲存 scope，修正 #138
- #141：editor-group topology 同步，修正 #129

### Documentation

- #123：更新至 38 suites / 249 tests

### Release gates

- TypeScript：通過
- Unit/property：38 suites / 249 tests passed
- Coverage gate：通過
- MCP bundle：通過
- Skills bundle：通過
- VSIX package with pre-release flag：通過，65 files / 5.1 MB
- 各 runtime PR 的 Validate 與 CodeQL：通過

### Deferred / known

- #124 symlink drag-and-drop 延後至後續 pre-release
- #132 dependency major upgrade 延後，避免在本班改變 Node baseline
- #135 EBADF 保持 monitoring，近期未重現但不宣稱根治

合併後 package.json 的奇數 minor 版本會讓 publish workflow 自動以 pre-release 發布至 Marketplace 與 Open VSX。