### PR TITLE
docs: rebalance README narrative + add Edo Tensei companion

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## 🚀 What is VirtualTabs?
 
-**VirtualTabs is a VS Code extension that provides custom "Virtual File Directories" outside of your native file system.** Unlike standard directories, VirtualTabs helps you create **independent logical file groups** based on your current development theme, while also providing **AI-Ready Coding Context** for quick copying. It is perfectly suited for Monorepo projects or large-scale applications using MVVM or MVC architectures.
+**VirtualTabs is a VS Code extension that provides custom "Virtual File Directories" outside of your native file system.** Unlike standard directories, VirtualTabs helps you create **independent logical file groups** based on your current development theme — keeping your spatial awareness intact even in complex workspaces. It also provides **AI-Ready Coding Context** for quick copying. Perfectly suited for Monorepo projects or large-scale applications using MVVM or MVC architectures.
 
 ---
 
@@ -25,6 +25,7 @@
 | :--- | :--- | :--- |
 | **Persistence** | Cleared on session close | **Saved permanently** per workspace |
 | **Grouping** | Folder-based only | **Logic-based** (Cross-directory support) |
+| **Spatial Awareness** | Tabs pile up with no task context | **Task-oriented groups** with auto-reveal and sync |
 | **AI Context** | Hard to gather manually | **One-click context generation** for LLMs |
 
 ![VirtualTabs vs Physical File System](docs/assets/virtual_vs_physical_concept.png)
@@ -124,7 +125,7 @@ In MVC/MVVM or large-scale projects, related files are often scattered across de
 
 ### 🤖 AI Context Export
 
-**The "Killer Feature" for LLM workflows.**
+**A power feature for LLM workflows.**
 
 1. Setup a group with all relevant files for your current task.
 2. Right-click the group → **Copy...** → **Copy Context for AI**.
@@ -140,7 +141,7 @@ In MVC/MVVM or large-scale projects, related files are often scattered across de
 
 VirtualTabs provides full AI agent integration via the **Model Context Protocol (MCP)**. Let your AI assistant (Cursor, Antigravity, Kiro, etc.) manage your workspace groups programmatically.
 
-- 🔌 **Standardized Tools**: Exposes 15+ tools for creating groups and explore the project.
+- 🔌 **Standardized Tools**: Exposes 19 tools for creating groups and exploring the project.
 - 🛡️ **Safety Mode**: Features a four-layer safety decision tree to prevent unintended disk changes.
   
   ![Safety Decision Tree](docs/assets/safety_decision_tree_en.png)
@@ -188,7 +189,7 @@ We welcome community contributions! Please check **[DEVELOPMENT.md](./DEVELOPMEN
 
 ---
 
-## 🔥 Recommended Companion
+## 🔥 Recommended Companions
 
 ### 🔥 Quick Prompt
 
@@ -202,6 +203,14 @@ We welcome community contributions! Please check **[DEVELOPMENT.md](./DEVELOPMEN
 Together, they reduce the cognitive overhead of AI-assisted development.
 
 Get Quick Prompt on [**VS Code Marketplace**](https://marketplace.visualstudio.com/items?itemName=winterdrive.quick-prompt) | [**Open VSX Registry**](https://open-vsx.org/extension/winterdrive/quick-prompt)
+
+### 🔁 Edo Tensei
+
+**For when the AI session itself needs to move, not just your files.**
+
+VirtualTabs solves *where am I in the workspace*. [Edo Tensei](https://github.com/Pain-Labs/Edo-Tensei) solves what happens when your AI quota runs out or you switch IDEs mid-task — it extracts local session history and packages it into a handoff prompt so the next agent can pick up where the last one left off.
+
+Get Edo Tensei on [**VS Code Marketplace**](https://marketplace.visualstudio.com/items?itemName=Pain-Labs.edo-tensei) | [**Open VSX Registry**](https://open-vsx.org/extension/Pain-Labs/edo-tensei)
 
 ---
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -13,7 +13,9 @@
 
 ## VirtualTabs とは？
 
-**VirtualTabs は、実際のファイルシステムとは別に、タスク単位の「仮想ファイルディレクトリ」を作れる VS Code 拡張です。** ファイルを移動したりコピーしたりせず、現在の作業テーマに合わせて永続的な論理グループを作成し、AI-ready context として一括コピーできます。Monorepo、MVC、MVVM、大規模プロジェクトに向いています。
+**VirtualTabs は、実際のファイルシステムとは別に、タスク単位の「仮想ファイルディレクトリ」を作れる VS Code 拡張です。** ファイルを移動したりコピーしたりせず、現在の作業テーマに合わせて永続的な論理グループを作成し、複雑なワークスペースでも空間的な見通しを保ちます。AI-ready context としての一括コピーにも対応しています。Monorepo、MVC、MVVM、大規模プロジェクトに向いています。
+
+---
 
 ![VirtualTabs vs Physical File System](assets/virtual_vs_physical_concept.png)
 
@@ -57,6 +59,8 @@ npx skills add winterdrive/vscode-virtual-tabs
 ## 推奨コンパニオン
 
 **Quick Prompt** は VirtualTabs と相性の良い補助ツールです。VirtualTabs はファイルをタスク単位で整理し、Quick Prompt は IDE 内でアイデアや次の作業を記録します。
+
+**Edo Tensei** は別の課題を解決します。VirtualTabs が「ワークスペースの中で自分が今どこにいるか」を解決するのに対し、[Edo Tensei](https://github.com/Pain-Labs/Edo-Tensei) は AI の利用枠が尽きたときや、作業の途中で IDE を乗り換えるときの課題を解決します——ローカルの session 履歴を抽出し、引き継ぎ用のプロンプトにまとめることで、次の agent が前の agent の続きから作業できるようにします。[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Pain-Labs.edo-tensei) または [Open VSX Registry](https://open-vsx.org/extension/Pain-Labs/edo-tensei) から入手できます。
 
 ## Support
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -13,7 +13,9 @@
 
 ## VirtualTabs란?
 
-**VirtualTabs는 실제 파일 시스템 밖에 작업 중심의 "가상 파일 디렉터리"를 만드는 VS Code 확장입니다.** 파일을 이동하거나 복사하지 않고, 현재 작업 주제에 맞는 영구적인 논리 그룹을 만들 수 있으며, 이를 AI-ready context로 한 번에 복사할 수 있습니다. Monorepo, MVC, MVVM, 대규모 프로젝트에 적합합니다.
+**VirtualTabs는 실제 파일 시스템 밖에 작업 중심의 "가상 파일 디렉터리"를 만드는 VS Code 확장입니다.** 파일을 이동하거나 복사하지 않고, 현재 작업 주제에 맞는 영구적인 논리 그룹을 만들어 복잡한 워크스페이스에서도 공간적 방향 감각을 유지할 수 있습니다. AI-ready context로의 일괄 복사도 지원합니다. Monorepo, MVC, MVVM, 대규모 프로젝트에 적합합니다.
+
+---
 
 ![VirtualTabs vs Physical File System](assets/virtual_vs_physical_concept.png)
 
@@ -54,9 +56,11 @@ npx skills add winterdrive/vscode-virtual-tabs
 
 자세한 내용은 [MCP Setup Guide](mcp-setup.md)를 참고하세요.
 
-## 추천 companion
+## 추천 companions
 
 **Quick Prompt**는 VirtualTabs와 함께 쓰기 좋은 도구입니다. VirtualTabs는 파일을 작업 단위로 정리하고, Quick Prompt는 IDE 안에서 아이디어와 다음 작업을 기록합니다.
+
+**Edo Tensei**는 또 다른 문제를 해결합니다. VirtualTabs가 "워크스페이스 안에서 내가 지금 어디에 있는지"를 해결한다면, [Edo Tensei](https://github.com/Pain-Labs/Edo-Tensei)는 AI 사용량이 바닥나거나 작업 도중 IDE를 옮겨야 할 때의 문제를 해결합니다——로컬 session 기록을 추출해 인계용 프롬프트로 정리해 두어서, 다음 agent가 이전 agent가 멈춘 지점부터 이어서 작업할 수 있게 해줍니다. [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Pain-Labs.edo-tensei) 또는 [Open VSX Registry](https://open-vsx.org/extension/Pain-Labs/edo-tensei)에서 받을 수 있습니다.
 
 ## Support
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -13,7 +13,9 @@
 
 ## 什么是 VirtualTabs？
 
-**VirtualTabs 是一个 VS Code 扩展，在真实文件系统之外提供自定义“虚拟文件目录”。** 它不会移动或复制磁盘文件，而是让你围绕当前任务建立持久的逻辑文件组，并一键复制 AI-ready context。它特别适合 Monorepo、MVC、MVVM 和大型项目。
+**VirtualTabs 是一个 VS Code 扩展，在真实文件系统之外提供自定义"虚拟文件目录"。** 它不会移动或复制磁盘文件，而是让你围绕当前任务建立持久的逻辑文件组——即使在复杂工作区中也能保持空间方向感。同时也支持一键复制 AI-ready context。它特别适合 Monorepo、MVC、MVVM 和大型项目。
+
+---
 
 ![VirtualTabs vs Physical File System](assets/virtual_vs_physical_concept.png)
 
@@ -57,6 +59,8 @@ npx skills add winterdrive/vscode-virtual-tabs
 ## 推荐搭配
 
 **Quick Prompt** 是 VirtualTabs 的互补工具：VirtualTabs 负责把文件按任务组织好，Quick Prompt 负责在 IDE 内记录想法与后续任务，减少 AI 辅助开发时的上下文切换。
+
+**Edo Tensei** 解决的是另一个问题：VirtualTabs 帮你理清"自己在工作区的哪里"，而当 AI 额度用尽或需要中途切换 IDE 时，[Edo Tensei](https://github.com/Pain-Labs/Edo-Tensei) 会提取本机的 session 历史并打包成交接提示词，让下一个 agent 能接着上一个的进度继续。可在 [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Pain-Labs.edo-tensei) 或 [Open VSX Registry](https://open-vsx.org/extension/Pain-Labs/edo-tensei) 获取。
 
 ## 支持
 

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -15,7 +15,7 @@
 
 ## 🚀 什麼是 VirtualTabs？
 
-**VirtualTabs 是一個 VS Code 擴充套件，在原生檔案目錄之外，提供自定義「虛擬檔案目錄」。** 不同於原生目錄，VirtualTabs 幫助您建立 **獨立的邏輯檔案群組**，可依照當前開發主題建立虛擬檔案目錄，同時也提供 **AI 就緒的編程上下文（AI-Ready Context）** 可快速複製。適合 Monorepo 專案或採用 MVVM、MVC 架構的大型專案。
+**VirtualTabs 是一個 VS Code 擴充套件，在原生檔案目錄之外，提供自定義「虛擬檔案目錄」。** 不同於原生目錄，VirtualTabs 幫助您建立 **獨立的邏輯檔案群組**，可依照當前開發主題建立虛擬檔案目錄——即使在複雜的工作區中也能維持您的空間方向感。同時也提供 **AI 就緒的編程上下文（AI-Ready Context）** 可快速複製。適合 Monorepo 專案或採用 MVVM、MVC 架構的大型專案。
 
 ---
 
@@ -25,6 +25,7 @@
 | :--- | :--- | :--- |
 | **持久性** | 關閉視窗即清除 | **永久保存** (依工作區記憶) |
 | **檔案分組** | 僅限資料夾結構 | **邏輯導向** (支援跨目錄) |
+| **空間感知** | 分頁堆積，缺乏任務脈絡 | **任務導向群組**，搭配自動追蹤與同步 |
 | **AI 上下文** | 需手動一一收集 | **一鍵生成** 給 LLM 的上下文 |
 
 ![VirtualTabs 虛擬與實體檔案系統概念圖](assets/virtual_vs_physical_concept.png)
@@ -124,7 +125,7 @@
 
 ### 🤖 AI 上下文匯出
 
-**LLM 工作流的殺手級功能。**
+**LLM 工作流的強力功能。**
 
 1. 定義一個與當面任務相關的檔案群組。
 2. 右鍵點擊群組 → **複製...** → **複製 AI 上下文 (Copy Context for AI)**。
@@ -140,7 +141,7 @@
 
 VirtualTabs 透過 **Model Context Protocol (MCP)** 提供完整的 AI Agent 整合。讓您的 AI 助手（Cursor, Antigravity, Kiro 等）能夠透過程式化管理您的工作區。
 
-- 🔌 **標準化工具**：提供 15+ 工具供 AI 建立群組及探索專案。
+- 🔌 **標準化工具**：提供 19 個工具供 AI 建立群組及探索專案。
 - 🛡️ **安全性**：具備四層安全決策樹，確保 AI 不會非預期地變動物理檔案。
 
   ![安全決策樹](assets/safety_decision_tree_zh.png)
@@ -202,6 +203,14 @@ VirtualTabs 透過 **Model Context Protocol (MCP)** 提供完整的 AI Agent 整
 兩者結合，大幅降低 AI 輔助開發的認知負荷。
 
 在 [**VS Code Marketplace**](https://marketplace.visualstudio.com/items?itemName=winterdrive.quick-prompt) | [**Open VSX Registry**](https://open-vsx.org/extension/winterdrive/quick-prompt) 取得 Quick Prompt
+
+### 🔁 Edo Tensei
+
+**當需要搬動的不只是檔案，而是 AI session 本身。**
+
+VirtualTabs 解決的是「我在工作區的哪裡」。[Edo Tensei](https://github.com/Pain-Labs/Edo-Tensei) 解決的是 AI 額度用盡或任務中途要切換 IDE 時的問題——它會擷取本機的 session 歷史，打包成交接提示詞，讓下一個 agent 能從上一個中斷的地方接手。
+
+在 [**VS Code Marketplace**](https://marketplace.visualstudio.com/items?itemName=Pain-Labs.edo-tensei) | [**Open VSX Registry**](https://open-vsx.org/extension/Pain-Labs/edo-tensei) 取得 Edo Tensei
 
 ---
 


### PR DESCRIPTION
## Summary
- 調整 README 敘事重心：空間認知與邏輯分組是核心價值，AI-Ready Context 定位為附加能力
- 新增 Edo Tensei 作為第三個推薦 companion（VirtualTabs = 空間認知、Quick Prompt = 非同步緩衝、Edo Tensei = 跨 IDE session 延續）
- MCP 工具數更新為實際數量

## Changes

### 敘事重心調整（英文 + 繁中）
- 「What is VirtualTabs」段落：加入「即使在複雜工作區也能維持空間方向感」，AI-Ready Context 降為附加描述
- 比較表格新增 **Spatial Awareness** 列
- 「AI Context Export」段落標題由 **"The Killer Feature"** 降級為 **"A power feature"**

### 新增 Edo Tensei companion（全 5 語言：EN / zh-TW / zh-CN / ja / ko）
- 「Recommended Companion」→「Recommended Companions」（因新增第二個 companion）
- 新增 Edo Tensei 介紹段落 + Marketplace / Open VSX 連結

### 其他校正
- MCP 工具數：「15+ tools」→「19 tools」（英文 + 繁中）

## Test plan
- [ ] 檢查 5 語言 README 渲染排版正常（連結、粗體、表格）
- [ ] 確認 Edo Tensei 連結可正常開啟
- [ ] 確認 19 個工具數字與目前 MCP server 實際 tool 數一致